### PR TITLE
feat: add project IDs support to call tools across different projects

### DIFF
--- a/app/api/upload/[token]/route.ts
+++ b/app/api/upload/[token]/route.ts
@@ -35,6 +35,7 @@ export async function POST(req: NextRequest, { params }) {
     );
   }
   const purpose = req.nextUrl.searchParams.get('purpose') ?? 'parse';
+  const projectId = req.nextUrl.searchParams.get('project_id') ?? undefined;
   const client = new LlamaCloud({
     apiKey: authToken,
     baseURL: process.env.LLAMA_CLOUD_BASE_URL,
@@ -43,6 +44,7 @@ export async function POST(req: NextRequest, { params }) {
     const fileObj = await client.files.create({
       file,
       purpose,
+      project_id: projectId,
     });
     // invalidate token only on success
     await kvStore.delete(token);

--- a/app/components/UploadForm.tsx
+++ b/app/components/UploadForm.tsx
@@ -2,7 +2,13 @@
 
 import { useRef, useState } from 'react';
 
-export default function UploadForm({ token }: { token: string }) {
+export default function UploadForm({
+  token,
+  projectId = undefined,
+}: {
+  token: string;
+  projectId?: string | undefined;
+}) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [purpose, setPurpose] = useState<string>('parse');
@@ -31,9 +37,18 @@ export default function UploadForm({ token }: { token: string }) {
     try {
       const formData = new FormData();
       formData.append('file', file);
-      const base = `${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}/api/upload/${token}`;
+      const prod_url =
+        process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL!.startsWith(
+          'http'
+        )
+          ? process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL!
+          : 'https://' + process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL!;
+      const base = `${prod_url}/api/upload/${token}`;
       const url = new URL(base);
       url.searchParams.set('purpose', purpose);
+      if (projectId) {
+        url.searchParams.set('project_id', projectId);
+      }
 
       const res = await fetch(url.toString(), {
         method: 'POST',

--- a/app/upload/[token]/page.tsx
+++ b/app/upload/[token]/page.tsx
@@ -1,7 +1,8 @@
 import UploadForm from '../../components/UploadForm';
 
 // @ts-expect-error params is implictly any
-export default async function UploadPage({ params }) {
+export default async function UploadPage({ params, searchParams }) {
   const { token } = await params;
-  return <UploadForm token={token} />;
+  const { project_id } = await searchParams;
+  return <UploadForm token={token} projectId={project_id} />;
 }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,14 @@
-import { registerOTel } from '@vercel/otel';
+import { registerOTel, OTLPHttpJsonTraceExporter } from '@vercel/otel';
 
 export function register() {
-  registerOTel({ serviceName: 'vercel-mcp-example' });
+  registerOTel({
+    serviceName: 'llamaindex-mcp-traces',
+    traceExporter: new OTLPHttpJsonTraceExporter({
+      url: `https://${process.env.AXIOM_DOMAIN}/v1/traces`,
+      headers: {
+        Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
+        'X-Axiom-Dataset': process.env.AXIOM_DATASET,
+      },
+    }),
+  });
 }

--- a/lib/business/llamaparse.ts
+++ b/lib/business/llamaparse.ts
@@ -20,12 +20,14 @@ export async function uploadFile({
   fileName,
   purpose = undefined,
   fileType = undefined,
+  projectId = undefined,
 }: {
   authToken: string;
   fileData: string | Uint8Array<ArrayBuffer>;
   fileName: string;
   purpose?: string | undefined;
   fileType?: string | undefined;
+  projectId?: string | undefined;
 }): Promise<string> {
   const client = new LlamaCloud({
     apiKey: authToken,
@@ -52,6 +54,7 @@ export async function uploadFile({
   const fileObj = await client.files.create({
     file: file,
     purpose: purpose ?? 'parse',
+    project_id: projectId,
   });
   return fileObj.id;
 }
@@ -62,12 +65,14 @@ export async function parseFile({
   tier = undefined,
   version = undefined,
   markdown = true,
+  projectId = undefined,
 }: {
   authToken: string;
   fileId: string;
   tier?: undefined | 'cost_effective' | 'agentic' | 'agentic_plus';
   version?: undefined | string;
   markdown?: boolean;
+  projectId?: string | undefined;
 }): Promise<ParsingResult> {
   const client = new LlamaCloud({
     apiKey: authToken,
@@ -78,6 +83,7 @@ export async function parseFile({
     version: version ?? 'latest',
     tier: tier ?? 'cost_effective',
     file_id: fileId,
+    project_id: projectId,
     expand,
   });
   const parsingResult: ParsingResult = {};
@@ -94,11 +100,13 @@ export async function classifyFile({
   fileId,
   categories,
   mode = undefined,
+  projectId = undefined,
 }: {
   authToken: string;
   fileId: string;
   categories: CategoryType[];
   mode?: 'FAST' | undefined;
+  projectId?: string | undefined;
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
@@ -111,6 +119,7 @@ export async function classifyFile({
       mode,
       rules: categories,
     },
+    project_id: projectId,
   });
 
   const baseDelay = 0.1;
@@ -118,7 +127,9 @@ export async function classifyFile({
   let classRes;
   // max 30 minutes of total wait time
   while (Date.now() - start < MaximumWaitingTime) {
-    const result = await client.classify.get(job.id);
+    const result = await client.classify.get(job.id, {
+      project_id: projectId,
+    });
     if (result.result) {
       classRes = result.result;
       break;
@@ -149,11 +160,13 @@ export async function splitFile({
   fileId,
   categories,
   allowUnacategorized = undefined,
+  projectId = undefined,
 }: {
   authToken: string;
   fileId: string;
   categories: SplitCategoryType[];
   allowUnacategorized?: 'include' | 'omit' | 'forbid' | undefined;
+  projectId?: string | undefined;
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
@@ -168,9 +181,12 @@ export async function splitFile({
         allow_uncategorized: allowUnacategorized ?? 'include',
       },
     },
+    project_id: projectId,
   });
 
-  const result = await client.beta.split.waitForCompletion(job.id);
+  const result = await client.beta.split.waitForCompletion(job.id, {
+    project_id: projectId,
+  });
   if (result.result) {
     const splitResult: SplitResult = {
       fileId: fileId,
@@ -193,4 +209,14 @@ export async function splitFile({
     return splitResult;
   }
   throw new Error('No split result was produced');
+}
+
+export async function getProjects(authToken: string): Promise<string[]> {
+  const client = new LlamaCloud({
+    apiKey: authToken,
+    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+  });
+  const projects = await client.projects.list();
+  const projectIds = projects.map((p) => p.id);
+  return projectIds;
 }

--- a/lib/mcp/tools/tools.ts
+++ b/lib/mcp/tools/tools.ts
@@ -1,6 +1,7 @@
 import { ensureUserAuthenticated } from '@/lib/auth/helpers';
 import {
   classifyFile,
+  getProjects,
   parseFile,
   splitFile,
   uploadFile,
@@ -27,6 +28,12 @@ export function registerLlamaParseTools(server: McpServer) {
         .optional()
         .describe(
           "Expected downstream processing workload for the file to upload. Allowed values: 'user_data', 'parse', 'extract', 'split', 'classify', 'sheet', 'agent_app'. Defaults to 'parse' if not provided."
+        ),
+      projectId: z
+        .string()
+        .optional()
+        .describe(
+          'Project ID that the tool should use. Uses the default project if not provided.'
         ),
     },
     async (args, extra) => {
@@ -90,9 +97,15 @@ export function registerLlamaParseTools(server: McpServer) {
         const url = new URL(base);
         url.searchParams.set('purpose', args.purpose ?? 'parse');
         url.searchParams.set('expires_at', expiresAt);
+        if (args.projectId) {
+          url.searchParams.set('project_id', args.projectId);
+        }
         const presignedUrl = url.toString();
         const urlUpload = new URL(`${prod_url}/upload/${token}`);
         urlUpload.searchParams.set('expires_at', expiresAt);
+        if (args.projectId) {
+          url.searchParams.set('project_id', args.projectId);
+        }
         return {
           content: [
             {
@@ -124,6 +137,12 @@ export function registerLlamaParseTools(server: McpServer) {
         .optional()
         .describe(
           "Expected downstream processing workload. Allowed values: 'user_data', 'parse', 'extract', 'split', 'classify', 'sheet', 'agent_app'. Defaults to 'parse' if not provided."
+        ),
+      projectId: z
+        .string()
+        .optional()
+        .describe(
+          'Project ID that the tool should use. Uses the default project if not provided.'
         ),
     },
     async (args, extra) => {
@@ -183,6 +202,7 @@ export function registerLlamaParseTools(server: McpServer) {
             fileName: args.fileName,
             fileType: args.fileType,
             purpose: args.purpose,
+            projectId: args.projectId,
           });
           logger.info(
             `Produced file ID as a result of file upload by URL: ${redactFileId(fileId)}`
@@ -200,6 +220,60 @@ export function registerLlamaParseTools(server: McpServer) {
           };
         } catch (err) {
           logger.error(`An error occurred while uploading file by URL: ${err}`);
+          span.setAttribute('tool.error', true);
+          span.end();
+          throw err;
+        }
+      });
+    }
+  );
+
+  server.tool(
+    'getUserProjects',
+    'Get all the project IDs associated to a user so that you can use them to call tools from different project IDs',
+    {},
+    async (_args, extra) => {
+      return tracer.startActiveSpan('tool.getUserProjects', async (span) => {
+        const { authInfo } = extra;
+        ensureUserAuthenticated(authInfo);
+        const logger = getLogger();
+        if (authInfo && authInfo.extra) {
+          if ('rateLimit' in authInfo.extra && authInfo.extra.rateLimit) {
+            logger.error(authInfo.extra.rateLimit);
+            span.setAttribute('ratelimit.error', true);
+            span.end();
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: authInfo.extra.rateLimit as string,
+                },
+              ],
+              isError: true,
+            } as {
+              content: { type: 'text'; text: string }[];
+              isError: boolean;
+            };
+          }
+        }
+        try {
+          const result = await getProjects(authInfo!.token);
+          logger.info(
+            `Successfully obtained ${result.length} projects for the user`
+          );
+          span.end();
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Project IDs: ${result.join(', ')}`,
+              },
+            ],
+          } as {
+            content: { type: 'text'; text: string }[];
+          };
+        } catch (err) {
+          logger.error(`An error occurred while getting projects: ${err}`);
           span.setAttribute('tool.error', true);
           span.end();
           throw err;
@@ -232,6 +306,12 @@ export function registerLlamaParseTools(server: McpServer) {
         .optional()
         .describe(
           'Whether to extract markdown or plain text. Defaults to true (extract markdown).'
+        ),
+      projectId: z
+        .string()
+        .optional()
+        .describe(
+          'Project ID that the tool should use. Uses the default project if not provided.'
         ),
     },
     async (args, extra) => {
@@ -268,6 +348,7 @@ export function registerLlamaParseTools(server: McpServer) {
             tier: args.tier,
             version: args.version,
             markdown: args.markdown,
+            projectId: args.projectId,
           });
           logger.info(`Successfully parsed ${redactFileId(args.fileId)}`);
           span.end();
@@ -310,6 +391,12 @@ export function registerLlamaParseTools(server: McpServer) {
         .describe(
           'Array of categories for the file to be classfied as. Category types should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
         ),
+      projectId: z
+        .string()
+        .optional()
+        .describe(
+          'Project ID that the tool should use. Uses the default project if not provided.'
+        ),
     },
     async (args, extra) => {
       return tracer.startActiveSpan('tool.classifyFile', async (span) => {
@@ -343,6 +430,7 @@ export function registerLlamaParseTools(server: McpServer) {
             fileId: args.fileId,
             mode: args.mode,
             categories: args.categories,
+            projectId: args.projectId,
           });
           logger.info(`Successfully classified ${redactFileId(args.fileId)}`);
           span.end();
@@ -386,6 +474,12 @@ export function registerLlamaParseTools(server: McpServer) {
         .describe(
           'Array of categories for the file to be classfied as. Category names should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
         ),
+      projectId: z
+        .string()
+        .optional()
+        .describe(
+          'Project ID that the tool should use. Uses the default project if not provided.'
+        ),
     },
     async (args, extra) => {
       return tracer.startActiveSpan('tool.splitFile', async (span) => {
@@ -423,6 +517,7 @@ export function registerLlamaParseTools(server: McpServer) {
             fileId: args.fileId,
             allowUnacategorized: args.allowUncategorized,
             categories: args.categories,
+            projectId: args.projectId,
           });
           logger.info(`Successfully classified ${redactFileId(args.fileId)}`);
           span.end();


### PR DESCRIPTION
Add project IDs support with:
- A tool to retrieve all project IDs
- Support for a project_id parameter in all tools and in file uploads
