### PR TITLE
feat: support configuration ID in extract/split/classify MCP routes to use a specific configuration ID

### DIFF
--- a/app/classify/[configId]/mcp/route.ts
+++ b/app/classify/[configId]/mcp/route.ts
@@ -23,12 +23,26 @@ type RouteContext = {
 async function route(request: Request, context: RouteContext) {
   const { configId } = await context.params;
 
-  const handler = buildMcpRouteHandler((server) => {
-    registerGetUserProjectsTool(server);
-    registerGetUploadUrlTool(server);
-    registerUploadFileByUrlTool(server);
-    registerClassifyFileTool(server, configId);
-  }, `/classify/${configId}`);
+  const handler = buildMcpRouteHandler(
+    (server) => {
+      registerGetUserProjectsTool(server);
+      registerGetUploadUrlTool(server);
+      registerUploadFileByUrlTool(server);
+      registerClassifyFileTool(server, configId);
+    },
+    `/classify/${configId}`,
+    {
+      serverInfo: {
+        name: 'llamacloud-classify-config-mcp',
+        version: '0.1.0',
+      },
+      instructions:
+        'LlamaCloud Classify MCP server bound to a saved classifier configuration ' +
+        `(${configId}). The classifyFile tool already knows the categories from the saved config, ` +
+        'so clients only need to upload a file (getUploadUrl + POST the file to the obtained URL) and call ' +
+        'classifyFile with the resulting file id.',
+    }
+  );
 
   return handler(request);
 }

--- a/app/classify/[configId]/mcp/route.ts
+++ b/app/classify/[configId]/mcp/route.ts
@@ -1,0 +1,36 @@
+import { buildMcpRouteHandler } from '@/lib/mcp/handler';
+import {
+  registerGetUploadUrlTool,
+  registerUploadFileByUrlTool,
+  registerGetUserProjectsTool,
+  registerClassifyFileTool,
+} from '@/lib/mcp/tools/tools';
+
+// Per-config classify MCP server. Endpoint: /classify/[configId]/mcp
+// The classifyFile tool is pre-bound to the configId from the URL, so
+// clients don't have to pass categories on every call — the saved
+// configuration on LlamaCloud supplies the categories/rules.
+//
+// As in /index/[indexId]/mcp, we build a fresh handler per request rather
+// than memoising per configId: `configId` is user-supplied and effectively
+// unbounded, so a process-lifetime cache would leak memory, and the
+// construction cost is dwarfed by the downstream LlamaParse API calls.
+
+type RouteContext = {
+  params: Promise<{ configId: string }>;
+};
+
+async function route(request: Request, context: RouteContext) {
+  const { configId } = await context.params;
+
+  const handler = buildMcpRouteHandler((server) => {
+    registerGetUserProjectsTool(server);
+    registerGetUploadUrlTool(server);
+    registerUploadFileByUrlTool(server);
+    registerClassifyFileTool(server, configId);
+  }, `/classify/${configId}`);
+
+  return handler(request);
+}
+
+export { route as GET, route as POST };

--- a/app/classify/mcp/route.ts
+++ b/app/classify/mcp/route.ts
@@ -7,11 +7,25 @@ import {
 } from '@/lib/mcp/tools/tools';
 
 // Classify-only MCP server. Endpoint: /classify/mcp
-const authHandler = buildMcpRouteHandler((server) => {
-  registerGetUserProjectsTool(server);
-  registerGetUploadUrlTool(server);
-  registerUploadFileByUrlTool(server);
-  registerClassifyFileTool(server);
-}, '/classify');
+const authHandler = buildMcpRouteHandler(
+  (server) => {
+    registerGetUserProjectsTool(server);
+    registerGetUploadUrlTool(server);
+    registerUploadFileByUrlTool(server);
+    registerClassifyFileTool(server);
+  },
+  '/classify',
+  {
+    serverInfo: {
+      name: 'llamacloud-classify-mcp',
+      version: '0.1.0',
+    },
+    instructions:
+      'LlamaCloud Classify MCP server for assigning user-defined categories to documents. ' +
+      'Upload a file via getUploadUrl + POST the file to the obtained URL, then call classifyFile with an array of ' +
+      'categories (lowercase snake_case names and clear descriptions) to get the predicted label. ' +
+      'Use getUserProjects to discover available projects.',
+  }
+);
 
 export { authHandler as GET, authHandler as POST };

--- a/app/extract/[configId]/mcp/route.ts
+++ b/app/extract/[configId]/mcp/route.ts
@@ -1,0 +1,35 @@
+import { buildMcpRouteHandler } from '@/lib/mcp/handler';
+import {
+  registerGetUploadUrlTool,
+  registerUploadFileByUrlTool,
+  registerGetUserProjectsTool,
+  registerExtractFileTool,
+} from '@/lib/mcp/tools/tools';
+
+// Per-config extract MCP server. Endpoint: /extract/[configId]/mcp
+// The extractFile tool is pre-bound to the configId from the URL, so
+// clients don't have to pass `configurationId` on every call.
+//
+// As in /index/[indexId]/mcp, we build a fresh handler per request rather
+// than memoising per configId: `configId` is user-supplied and effectively
+// unbounded, so a process-lifetime cache would leak memory, and the
+// construction cost is dwarfed by the downstream LlamaParse API calls.
+
+type RouteContext = {
+  params: Promise<{ configId: string }>;
+};
+
+async function route(request: Request, context: RouteContext) {
+  const { configId } = await context.params;
+
+  const handler = buildMcpRouteHandler((server) => {
+    registerGetUserProjectsTool(server);
+    registerGetUploadUrlTool(server);
+    registerUploadFileByUrlTool(server);
+    registerExtractFileTool(server, configId);
+  }, `/extract/${configId}`);
+
+  return handler(request);
+}
+
+export { route as GET, route as POST };

--- a/app/extract/[configId]/mcp/route.ts
+++ b/app/extract/[configId]/mcp/route.ts
@@ -22,12 +22,26 @@ type RouteContext = {
 async function route(request: Request, context: RouteContext) {
   const { configId } = await context.params;
 
-  const handler = buildMcpRouteHandler((server) => {
-    registerGetUserProjectsTool(server);
-    registerGetUploadUrlTool(server);
-    registerUploadFileByUrlTool(server);
-    registerExtractFileTool(server, configId);
-  }, `/extract/${configId}`);
+  const handler = buildMcpRouteHandler(
+    (server) => {
+      registerGetUserProjectsTool(server);
+      registerGetUploadUrlTool(server);
+      registerUploadFileByUrlTool(server);
+      registerExtractFileTool(server, configId);
+    },
+    `/extract/${configId}`,
+    {
+      serverInfo: {
+        name: 'llamacloud-extract-config-mcp',
+        version: '0.1.0',
+      },
+      instructions:
+        'LlamaExtract MCP server bound to a saved extraction configuration ' +
+        `(${configId}). The extractFile tool already knows the schema from the saved config, so ` +
+        'clients only need to upload a file (getUploadUrl + POST the file to the obtained URL) and call extractFile ' +
+        'with the resulting file id to get structured JSON output.',
+    }
+  );
 
   return handler(request);
 }

--- a/app/extract/mcp/route.ts
+++ b/app/extract/mcp/route.ts
@@ -9,12 +9,27 @@ import {
 
 // Extract-only MCP server. Endpoint: /extract/mcp
 // Includes the two extract tools, the file upload helpers and getUserProjects.
-const authHandler = buildMcpRouteHandler((server) => {
-  registerGetUserProjectsTool(server);
-  registerGetUploadUrlTool(server);
-  registerUploadFileByUrlTool(server);
-  registerGenerateExtractionConfigTool(server);
-  registerExtractFileTool(server);
-}, '/extract');
+const authHandler = buildMcpRouteHandler(
+  (server) => {
+    registerGetUserProjectsTool(server);
+    registerGetUploadUrlTool(server);
+    registerUploadFileByUrlTool(server);
+    registerGenerateExtractionConfigTool(server);
+    registerExtractFileTool(server);
+  },
+  '/extract',
+  {
+    serverInfo: {
+      name: 'llamacloud-extract-mcp',
+      version: '0.1.0',
+    },
+    instructions:
+      'LlamaExtract MCP server for pulling structured data out of documents. Typical flow: ' +
+      '(1) call generateExtractionConfig with a natural-language description to draft a schema, ' +
+      '(2) upload a file via getUploadUrl and POST the file to the obtained URL, ' +
+      '(3) call extractFile with the file id and the extraction config to get structured JSON. ' +
+      'Use getUserProjects to discover available projects.',
+  }
+);
 
 export { authHandler as GET, authHandler as POST };

--- a/app/index/[indexId]/mcp/route.ts
+++ b/app/index/[indexId]/mcp/route.ts
@@ -26,13 +26,28 @@ type RouteContext = {
 async function route(request: Request, context: RouteContext) {
   const { indexId } = await context.params;
 
-  const handler = buildMcpRouteHandler((server) => {
-    registerGetUserProjectsTool(server);
-    registerFindFilesInIndexTool(server, indexId);
-    registerReadFileFromIndexTool(server, indexId);
-    registerGrepFileFromIndexTool(server, indexId);
-    registerRetrieveFromIndexTool(server, indexId);
-  }, `/index/${indexId}`);
+  const handler = buildMcpRouteHandler(
+    (server) => {
+      registerGetUserProjectsTool(server);
+      registerFindFilesInIndexTool(server, indexId);
+      registerReadFileFromIndexTool(server, indexId);
+      registerGrepFileFromIndexTool(server, indexId);
+      registerRetrieveFromIndexTool(server, indexId);
+    },
+    `/index/${indexId}`,
+    {
+      serverInfo: {
+        name: 'llamacloud-index-mcp',
+        version: '0.1.0',
+      },
+      instructions:
+        'LlamaCloud Index MCP server bound to a single index ' +
+        `(${indexId}). Use findFilesInIndex to list files, readFileFromIndex to fetch a ` +
+        'specific file’s parsed contents, grepFileFromIndex to search inside a file with a ' +
+        'regex/literal pattern, and retrieveFromIndex for semantic / hybrid retrieval across ' +
+        'the whole index. getUserProjects is available to fetch the user project associated with the index ID.',
+    }
+  );
 
   return handler(request);
 }

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -2,6 +2,18 @@ import { buildMcpRouteHandler } from '@/lib/mcp/handler';
 import { registerLlamaParseTools } from '@/lib/mcp/tools/tools';
 
 // Full MCP server: exposes every LlamaParse tool. Endpoint: /mcp
-const authHandler = buildMcpRouteHandler(registerLlamaParseTools, '');
+const authHandler = buildMcpRouteHandler(registerLlamaParseTools, '', {
+  serverInfo: {
+    name: 'llamacloud-mcp',
+    version: '0.1.0',
+  },
+  instructions:
+    'LlamaParse Platform MCP server exposing the full set of Parse, Extract, Split, Classify and Index tools. ' +
+    'Use the upload helpers (getUploadUrl, uploadFileByUrl) to push a local file to LlamaCloud, ' +
+    'then call parseFile, classifyFile, splitFile, or extractFile to process it. ' +
+    'Use getUserProjects to discover available projects, listIndexes to find indexes, and the ' +
+    'index tools (findFilesInIndex, readFileFromIndex, grepFileFromIndex, retrieveFromIndex) to ' +
+    'search and read documents in an existing index.',
+});
 
 export { authHandler as GET, authHandler as POST };

--- a/app/parse/mcp/route.ts
+++ b/app/parse/mcp/route.ts
@@ -8,11 +8,26 @@ import {
 
 // Parse-only MCP server. Endpoint: /parse/mcp
 // Includes parseFile, the file upload helpers it needs, and getUserProjects.
-const authHandler = buildMcpRouteHandler((server) => {
-  registerGetUserProjectsTool(server);
-  registerGetUploadUrlTool(server);
-  registerUploadFileByUrlTool(server);
-  registerParseFileTool(server);
-}, '/parse');
+const authHandler = buildMcpRouteHandler(
+  (server) => {
+    registerGetUserProjectsTool(server);
+    registerGetUploadUrlTool(server);
+    registerUploadFileByUrlTool(server);
+    registerParseFileTool(server);
+  },
+  '/parse',
+  {
+    serverInfo: {
+      name: 'llamacloud-parse-mcp',
+      version: '0.1.0',
+    },
+    instructions:
+      'LlamaParse MCP server for converting documents (PDFs, Office files, images, etc.) into ' +
+      'structured text/markdown. Typical flow: (1) call getUploadUrl to obtain a signed upload URL, ' +
+      '(2) POST your file to that URL (or call uploadFileByUrl to have the server fetch it for you), ' +
+      '(3) call parseFile with the returned file id to run LlamaParse. Use getUserProjects to pick ' +
+      'a target project when needed.',
+  }
+);
 
 export { authHandler as GET, authHandler as POST };

--- a/app/split/[configId]/mcp/route.ts
+++ b/app/split/[configId]/mcp/route.ts
@@ -24,12 +24,26 @@ type RouteContext = {
 async function route(request: Request, context: RouteContext) {
   const { configId } = await context.params;
 
-  const handler = buildMcpRouteHandler((server) => {
-    registerGetUserProjectsTool(server);
-    registerGetUploadUrlTool(server);
-    registerUploadFileByUrlTool(server);
-    registerSplitFileTool(server, configId);
-  }, `/split/${configId}`);
+  const handler = buildMcpRouteHandler(
+    (server) => {
+      registerGetUserProjectsTool(server);
+      registerGetUploadUrlTool(server);
+      registerUploadFileByUrlTool(server);
+      registerSplitFileTool(server, configId);
+    },
+    `/split/${configId}`,
+    {
+      serverInfo: {
+        name: 'llamacloud-split-config-mcp',
+        version: '0.1.0',
+      },
+      instructions:
+        'LlamaCloud Split MCP server bound to a saved split configuration ' +
+        `(${configId}). The splitFile tool already knows the categories and splitting strategy ` +
+        'from the saved config, so clients only need to upload a file (getUploadUrl + ' +
+        'uploadFileByUrl) and call splitFile with the resulting file id.',
+    }
+  );
 
   return handler(request);
 }

--- a/app/split/[configId]/mcp/route.ts
+++ b/app/split/[configId]/mcp/route.ts
@@ -1,0 +1,37 @@
+import { buildMcpRouteHandler } from '@/lib/mcp/handler';
+import {
+  registerGetUploadUrlTool,
+  registerUploadFileByUrlTool,
+  registerGetUserProjectsTool,
+  registerSplitFileTool,
+} from '@/lib/mcp/tools/tools';
+
+// Per-config split MCP server. Endpoint: /split/[configId]/mcp
+// The splitFile tool is pre-bound to the configId from the URL, so
+// clients don't have to pass categories on every call — the saved
+// configuration on LlamaCloud supplies the categories and splitting
+// strategy.
+//
+// As in /index/[indexId]/mcp, we build a fresh handler per request rather
+// than memoising per configId: `configId` is user-supplied and effectively
+// unbounded, so a process-lifetime cache would leak memory, and the
+// construction cost is dwarfed by the downstream LlamaParse API calls.
+
+type RouteContext = {
+  params: Promise<{ configId: string }>;
+};
+
+async function route(request: Request, context: RouteContext) {
+  const { configId } = await context.params;
+
+  const handler = buildMcpRouteHandler((server) => {
+    registerGetUserProjectsTool(server);
+    registerGetUploadUrlTool(server);
+    registerUploadFileByUrlTool(server);
+    registerSplitFileTool(server, configId);
+  }, `/split/${configId}`);
+
+  return handler(request);
+}
+
+export { route as GET, route as POST };

--- a/app/split/mcp/route.ts
+++ b/app/split/mcp/route.ts
@@ -7,11 +7,25 @@ import {
 } from '@/lib/mcp/tools/tools';
 
 // Split-only MCP server. Endpoint: /split/mcp
-const authHandler = buildMcpRouteHandler((server) => {
-  registerGetUserProjectsTool(server);
-  registerGetUploadUrlTool(server);
-  registerUploadFileByUrlTool(server);
-  registerSplitFileTool(server);
-}, '/split');
+const authHandler = buildMcpRouteHandler(
+  (server) => {
+    registerGetUserProjectsTool(server);
+    registerGetUploadUrlTool(server);
+    registerUploadFileByUrlTool(server);
+    registerSplitFileTool(server);
+  },
+  '/split',
+  {
+    serverInfo: {
+      name: 'llamacloud-split-mcp',
+      version: '0.1.0',
+    },
+    instructions:
+      'LlamaCloud Split MCP server for splitting a document into category-labelled sections. ' +
+      'Upload a file via getUploadUrl + uploadFileByUrl, then call splitFile with an array of ' +
+      'categories (lowercase snake_case names and clear descriptions) to get per-section ' +
+      'classifications. Use getUserProjects to discover available projects.',
+  }
+);
 
 export { authHandler as GET, authHandler as POST };

--- a/lib/business/llamaparse.ts
+++ b/lib/business/llamaparse.ts
@@ -102,26 +102,42 @@ export async function classifyFile({
   categories,
   mode = undefined,
   projectId = undefined,
+  configurationId = undefined,
 }: {
   authToken: string;
   fileId: string;
-  categories: CategoryType[];
+  categories?: CategoryType[];
   mode?: 'FAST' | undefined;
   projectId?: string | undefined;
+  configurationId?: string | undefined;
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
     baseURL: process.env.LLAMA_CLOUD_BASE_URL,
   });
 
-  const job = await client.classify.create({
-    file_input: fileId,
-    configuration: {
-      mode,
-      rules: categories,
-    },
-    project_id: projectId,
-  });
+  if (!configurationId && !categories) {
+    throw new Error(
+      'classifyFile requires either `categories` or a `configurationId`'
+    );
+  }
+
+  const job = await client.classify.create(
+    configurationId
+      ? {
+          file_input: fileId,
+          configuration_id: configurationId,
+          project_id: projectId,
+        }
+      : {
+          file_input: fileId,
+          configuration: {
+            mode,
+            rules: categories!,
+          },
+          project_id: projectId,
+        }
+  );
 
   const baseDelay = 0.1;
   const start = Date.now();
@@ -162,28 +178,44 @@ export async function splitFile({
   categories,
   allowUnacategorized = undefined,
   projectId = undefined,
+  configurationId = undefined,
 }: {
   authToken: string;
   fileId: string;
-  categories: SplitCategoryType[];
+  categories?: SplitCategoryType[];
   allowUnacategorized?: 'include' | 'omit' | 'forbid' | undefined;
   projectId?: string | undefined;
+  configurationId?: string | undefined;
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
     baseURL: process.env.LLAMA_CLOUD_BASE_URL,
   });
 
-  const job = await client.beta.split.create({
-    document_input: { type: 'file_id', value: fileId },
-    configuration: {
-      categories,
-      splitting_strategy: {
-        allow_uncategorized: allowUnacategorized ?? 'include',
-      },
-    },
-    project_id: projectId,
-  });
+  if (!configurationId && !categories) {
+    throw new Error(
+      'splitFile requires either `categories` or a `configurationId`'
+    );
+  }
+
+  const job = await client.beta.split.create(
+    configurationId
+      ? {
+          document_input: { type: 'file_id', value: fileId },
+          configuration_id: configurationId,
+          project_id: projectId,
+        }
+      : {
+          document_input: { type: 'file_id', value: fileId },
+          configuration: {
+            categories: categories!,
+            splitting_strategy: {
+              allow_uncategorized: allowUnacategorized ?? 'include',
+            },
+          },
+          project_id: projectId,
+        }
+  );
 
   const result = await client.beta.split.waitForCompletion(job.id, {
     project_id: projectId,

--- a/lib/mcp/handler.ts
+++ b/lib/mcp/handler.ts
@@ -45,6 +45,14 @@ async function applyRateLimit(request: Request): Promise<Response | null> {
 const jwksUrl = new URL(`https://api.workos.com/sso/jwks/${clientId}`);
 const JWKS = createRemoteJWKSet(jwksUrl);
 
+type McpServerInfo = {
+  instructions: string;
+  serverInfo: {
+    name: string;
+    version: string;
+  };
+};
+
 /**
  * Build a Next.js route handler that exposes an MCP server over Streamable HTTP,
  * wrapped with WorkOS auth + rate limiting.
@@ -52,16 +60,18 @@ const JWKS = createRemoteJWKSet(jwksUrl);
  * @param register   Function that registers tools on the MCP server.
  * @param basePath   Base path under which the `/mcp` endpoint is mounted.
  *                   For example, basePath: '/parse' → endpoint '/parse/mcp'.
+ * @param serverInfo Information about the server, including name, instructions and version.
  */
 export function buildMcpRouteHandler(
   register: (server: McpServer) => void,
-  basePath: string
+  basePath: string,
+  serverInfo?: McpServerInfo
 ) {
   const handler = createMcpHandler(
     (server) => {
       register(server);
     },
-    {},
+    { ...serverInfo },
     { basePath }
   );
 

--- a/lib/mcp/tools/tools.ts
+++ b/lib/mcp/tools/tools.ts
@@ -371,12 +371,6 @@ export function registerClassifyFileTool(
       .describe(
         'ID of the file to classify, as returned by the file upload tool or provided by the user'
       ),
-    projectId: z
-      .string()
-      .optional()
-      .describe(
-        'Project ID that the tool should use. Uses the default project if not provided.'
-      ),
   };
   if (!fixedConfigurationId) {
     schema.mode = z
@@ -388,6 +382,16 @@ export function registerClassifyFileTool(
       .describe(
         'Array of categories for the file to be classfied as. Category types should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
       );
+    schema.projectId = z
+      .string()
+      .optional()
+      .describe(
+        'Project ID that the tool should use. Uses the default project if not provided.'
+      );
+  } else {
+    schema.projectId = z
+      .string()
+      .describe('Project ID that the tool should use.');
   }
   const description = fixedConfigurationId
     ? `Classify a file using the saved classify configuration ${fixedConfigurationId}. Provide the file ID (as returned by the upload tool or supplied by the user); the categories are pulled from the saved configuration.`
@@ -450,12 +454,6 @@ export function registerSplitFileTool(
       .describe(
         'ID of the file to split, as returned by the file upload tool or provided by the user'
       ),
-    projectId: z
-      .string()
-      .optional()
-      .describe(
-        'Project ID that the tool should use. Uses the default project if not provided.'
-      ),
   };
   if (!fixedConfigurationId) {
     schema.allowUncategorized = z
@@ -469,6 +467,16 @@ export function registerSplitFileTool(
       .describe(
         'Array of categories for the file to be classfied as. Category names should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
       );
+    schema.projectId = z
+      .string()
+      .optional()
+      .describe(
+        'Project ID that the tool should use. Uses the default project if not provided.'
+      );
+  } else {
+    schema.projectId = z
+      .string()
+      .describe('Project ID that the tool should use.');
   }
   const description = fixedConfigurationId
     ? `Split a file into category-based segments using the saved split configuration ${fixedConfigurationId}. Provide the file ID (as returned by the upload tool or supplied by the user); the categories and splitting strategy are pulled from the saved configuration.`
@@ -607,12 +615,6 @@ export function registerExtractFileTool(
       .describe(
         'ID of the file to extract, as returned by the file upload tool or provided by the user'
       ),
-    projectId: z
-      .string()
-      .optional()
-      .describe(
-        'Project ID that the tool should use. Uses the default project if not provided.'
-      ),
   };
   if (!fixedConfigurationId) {
     schema.configurationId = z
@@ -620,6 +622,16 @@ export function registerExtractFileTool(
       .describe(
         'ID of the configuration to use to extract data from the file, as provided by the `generateExtractionConfig` tool.'
       );
+    schema.projectId = z
+      .string()
+      .optional()
+      .describe(
+        'Project ID that the tool should use. Uses the default project if not provided.'
+      );
+  } else {
+    schema.projectId = z
+      .string()
+      .describe('Project ID that the tool should use.');
   }
   const description = fixedConfigurationId
     ? `Extract structured data from a file using the saved extraction configuration ${fixedConfigurationId}. Returns the extracted structured data.`

--- a/lib/mcp/tools/tools.ts
+++ b/lib/mcp/tools/tools.ts
@@ -361,146 +361,168 @@ export function registerParseFileTool(server: McpServer) {
 // Classify tool
 // =====================
 
-export function registerClassifyFileTool(server: McpServer) {
-  server.tool(
-    'classifyFile',
-    'Classify a file (based on specific categories) providing its file ID. Use with file IDs obtained with the uploadFileChunk tool or that the user provided',
-    {
-      fileId: z
-        .string()
-        .describe(
-          'ID of the file to classify, as returned by the file upload tool or provided by the user'
-        ),
-      mode: z
-        .literal('FAST')
-        .optional()
-        .describe('Classification mode to use.'),
-      categories: z
-        .array(Category)
-        .describe(
-          'Array of categories for the file to be classfied as. Category types should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
-        ),
-      projectId: z
-        .string()
-        .optional()
-        .describe(
-          'Project ID that the tool should use. Uses the default project if not provided.'
-        ),
-    },
-    async (args, extra) => {
-      return tracer.startActiveSpan('tool.classifyFile', async (span) => {
-        span.setAttribute('tool.file_id', redactFileId(args.fileId));
-        if (args.mode) span.setAttribute('tool.mode', args.mode);
-        const { authInfo } = extra;
-        ensureUserAuthenticated(authInfo);
-        const logger = getLogger();
-        const rl = checkRateLimitedResponse(authInfo, span);
-        if (rl) return rl;
-        try {
-          const result = await classifyFile({
-            authToken: authInfo!.token,
-            fileId: args.fileId,
-            mode: args.mode,
-            categories: args.categories,
-            projectId: args.projectId,
-          });
-          logger.info(`Successfully classified ${redactFileId(args.fileId)}`);
-          span.end();
-          return {
-            content: [
-              {
-                type: 'text',
-                text: result.asString(),
-              },
-            ],
-          } as {
-            content: { type: 'text'; text: string }[];
-          };
-        } catch (err) {
-          logger.error(`An error occurred while classifying: ${err}`);
-          span.setAttribute('tool.error', true);
-          span.end();
-          throw err;
-        }
-      });
-    }
-  );
+export function registerClassifyFileTool(
+  server: McpServer,
+  fixedConfigurationId?: string
+) {
+  const schema: Record<string, z.ZodTypeAny> = {
+    fileId: z
+      .string()
+      .describe(
+        'ID of the file to classify, as returned by the file upload tool or provided by the user'
+      ),
+    projectId: z
+      .string()
+      .optional()
+      .describe(
+        'Project ID that the tool should use. Uses the default project if not provided.'
+      ),
+  };
+  if (!fixedConfigurationId) {
+    schema.mode = z
+      .literal('FAST')
+      .optional()
+      .describe('Classification mode to use.');
+    schema.categories = z
+      .array(Category)
+      .describe(
+        'Array of categories for the file to be classfied as. Category types should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
+      );
+  }
+  const description = fixedConfigurationId
+    ? `Classify a file using the saved classify configuration ${fixedConfigurationId}. Provide the file ID (as returned by the upload tool or supplied by the user); the categories are pulled from the saved configuration.`
+    : 'Classify a file (based on specific categories) providing its file ID. Use with file IDs obtained with the uploadFileChunk tool or that the user provided';
+  server.tool('classifyFile', description, schema, async (args, extra) => {
+    return tracer.startActiveSpan('tool.classifyFile', async (span) => {
+      span.setAttribute('tool.file_id', redactFileId(args.fileId as string));
+      if (args.mode) span.setAttribute('tool.mode', args.mode as string);
+      if (fixedConfigurationId)
+        span.setAttribute('tool.config_id', redactFileId(fixedConfigurationId));
+      const { authInfo } = extra;
+      ensureUserAuthenticated(authInfo);
+      const logger = getLogger();
+      const rl = checkRateLimitedResponse(authInfo, span);
+      if (rl) return rl;
+      try {
+        const result = await classifyFile({
+          authToken: authInfo!.token,
+          fileId: args.fileId as string,
+          mode: args.mode as 'FAST' | undefined,
+          categories: args.categories as never,
+          projectId: args.projectId as string | undefined,
+          configurationId: fixedConfigurationId,
+        });
+        logger.info(
+          `Successfully classified ${redactFileId(args.fileId as string)}`
+        );
+        span.end();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: result.asString(),
+            },
+          ],
+        } as {
+          content: { type: 'text'; text: string }[];
+        };
+      } catch (err) {
+        logger.error(`An error occurred while classifying: ${err}`);
+        span.setAttribute('tool.error', true);
+        span.end();
+        throw err;
+      }
+    });
+  });
 }
 
 // =====================
 // Split tool
 // =====================
 
-export function registerSplitFileTool(server: McpServer) {
-  server.tool(
-    'splitFile',
-    'Split a file into category-based segments providing its file ID. Use with file IDs obtained with the uploadFileChunk tool or that the user provided',
-    {
-      fileId: z
-        .string()
-        .describe(
-          'ID of the file to split, as returned by the file upload tool or provided by the user'
-        ),
-      allowUncategorized: z
-        .enum(['omit', 'include', 'forbid'])
-        .optional()
-        .describe(
-          'Whether to omit, include or forbid uncategorized results. If you forbid uncategorized results, you force categorization even when the confidence is low. Defaults to `include`'
-        ),
-      categories: z
-        .array(SplitCategory)
-        .describe(
-          'Array of categories for the file to be classfied as. Category names should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
-        ),
-      projectId: z
-        .string()
-        .optional()
-        .describe(
-          'Project ID that the tool should use. Uses the default project if not provided.'
-        ),
-    },
-    async (args, extra) => {
-      return tracer.startActiveSpan('tool.splitFile', async (span) => {
-        span.setAttribute('tool.file_id', redactFileId(args.fileId));
-        if (args.allowUncategorized)
-          span.setAttribute(
-            'tool.allow_uncategorized',
-            args.allowUncategorized
-          );
-        const { authInfo } = extra;
-        ensureUserAuthenticated(authInfo);
-        const logger = getLogger();
-        const rl = checkRateLimitedResponse(authInfo, span);
-        if (rl) return rl;
-        try {
-          const result = await splitFile({
-            authToken: authInfo!.token,
-            fileId: args.fileId,
-            allowUnacategorized: args.allowUncategorized,
-            categories: args.categories,
-            projectId: args.projectId,
-          });
-          logger.info(`Successfully split ${redactFileId(args.fileId)}`);
-          span.end();
-          return {
-            content: [
-              {
-                type: 'text',
-                text: result.asString(),
-              },
-            ],
-          } as {
-            content: { type: 'text'; text: string }[];
-          };
-        } catch (err) {
-          logger.error(`An error occurred while splitting: ${err}`);
-          span.setAttribute('tool.error', true);
-          span.end();
-          throw err;
-        }
-      });
-    }
-  );
+export function registerSplitFileTool(
+  server: McpServer,
+  fixedConfigurationId?: string
+) {
+  const schema: Record<string, z.ZodTypeAny> = {
+    fileId: z
+      .string()
+      .describe(
+        'ID of the file to split, as returned by the file upload tool or provided by the user'
+      ),
+    projectId: z
+      .string()
+      .optional()
+      .describe(
+        'Project ID that the tool should use. Uses the default project if not provided.'
+      ),
+  };
+  if (!fixedConfigurationId) {
+    schema.allowUncategorized = z
+      .enum(['omit', 'include', 'forbid'])
+      .optional()
+      .describe(
+        'Whether to omit, include or forbid uncategorized results. If you forbid uncategorized results, you force categorization even when the confidence is low. Defaults to `include`'
+      );
+    schema.categories = z
+      .array(SplitCategory)
+      .describe(
+        'Array of categories for the file to be classfied as. Category names should be lowercase and use snake_case. Category descriptions should be exaustive but not longer than 500 characters'
+      );
+  }
+  const description = fixedConfigurationId
+    ? `Split a file into category-based segments using the saved split configuration ${fixedConfigurationId}. Provide the file ID (as returned by the upload tool or supplied by the user); the categories and splitting strategy are pulled from the saved configuration.`
+    : 'Split a file into category-based segments providing its file ID. Use with file IDs obtained with the uploadFileChunk tool or that the user provided';
+  server.tool('splitFile', description, schema, async (args, extra) => {
+    return tracer.startActiveSpan('tool.splitFile', async (span) => {
+      span.setAttribute('tool.file_id', redactFileId(args.fileId as string));
+      if (args.allowUncategorized)
+        span.setAttribute(
+          'tool.allow_uncategorized',
+          args.allowUncategorized as string
+        );
+      if (fixedConfigurationId)
+        span.setAttribute('tool.config_id', redactFileId(fixedConfigurationId));
+      const { authInfo } = extra;
+      ensureUserAuthenticated(authInfo);
+      const logger = getLogger();
+      const rl = checkRateLimitedResponse(authInfo, span);
+      if (rl) return rl;
+      try {
+        const result = await splitFile({
+          authToken: authInfo!.token,
+          fileId: args.fileId as string,
+          allowUnacategorized: args.allowUncategorized as
+            | 'omit'
+            | 'include'
+            | 'forbid'
+            | undefined,
+          categories: args.categories as never,
+          projectId: args.projectId as string | undefined,
+          configurationId: fixedConfigurationId,
+        });
+        logger.info(
+          `Successfully split ${redactFileId(args.fileId as string)}`
+        );
+        span.end();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: result.asString(),
+            },
+          ],
+        } as {
+          content: { type: 'text'; text: string }[];
+        };
+      } catch (err) {
+        logger.error(`An error occurred while splitting: ${err}`);
+        span.setAttribute('tool.error', true);
+        span.end();
+        throw err;
+      }
+    });
+  });
 }
 
 // =====================
@@ -575,68 +597,73 @@ export function registerGenerateExtractionConfigTool(server: McpServer) {
   );
 }
 
-export function registerExtractFileTool(server: McpServer) {
-  server.tool(
-    'extractFile',
-    'Extract structured data from a file based on the configuration created with the `generateExtractionConfig` tool. Returns the extracted structured data.',
-    {
-      fileId: z
-        .string()
-        .describe(
-          'ID of the file to extract, as returned by the file upload tool or provided by the user'
-        ),
-      configurationId: z
-        .string()
-        .describe(
-          'ID of the configuration to use to extract data from the file, as provided by the `generateExtractionConfig` tool.'
-        ),
-      projectId: z
-        .string()
-        .optional()
-        .describe(
-          'Project ID that the tool should use. Uses the default project if not provided.'
-        ),
-    },
-    async (args, extra) => {
-      return tracer.startActiveSpan('tool.extractFile', async (span) => {
-        span.setAttribute('tool.file_id', redactFileId(args.fileId));
-        span.setAttribute(
-          'tool.config_name',
-          redactFileId(args.configurationId)
+export function registerExtractFileTool(
+  server: McpServer,
+  fixedConfigurationId?: string
+) {
+  const schema: Record<string, z.ZodTypeAny> = {
+    fileId: z
+      .string()
+      .describe(
+        'ID of the file to extract, as returned by the file upload tool or provided by the user'
+      ),
+    projectId: z
+      .string()
+      .optional()
+      .describe(
+        'Project ID that the tool should use. Uses the default project if not provided.'
+      ),
+  };
+  if (!fixedConfigurationId) {
+    schema.configurationId = z
+      .string()
+      .describe(
+        'ID of the configuration to use to extract data from the file, as provided by the `generateExtractionConfig` tool.'
+      );
+  }
+  const description = fixedConfigurationId
+    ? `Extract structured data from a file using the saved extraction configuration ${fixedConfigurationId}. Returns the extracted structured data.`
+    : 'Extract structured data from a file based on the configuration created with the `generateExtractionConfig` tool. Returns the extracted structured data.';
+  server.tool('extractFile', description, schema, async (args, extra) => {
+    return tracer.startActiveSpan('tool.extractFile', async (span) => {
+      const configurationId =
+        fixedConfigurationId ?? (args.configurationId as string);
+      span.setAttribute('tool.file_id', redactFileId(args.fileId as string));
+      span.setAttribute('tool.config_name', redactFileId(configurationId));
+      const { authInfo } = extra;
+      ensureUserAuthenticated(authInfo);
+      const logger = getLogger();
+      const rl = checkRateLimitedResponse(authInfo, span);
+      if (rl) return rl;
+      try {
+        const result = await extract({
+          token: authInfo!.token,
+          fileId: args.fileId as string,
+          projectId: args.projectId as string | undefined,
+          configurationId,
+        });
+        logger.info(
+          `Successfully extracted ${redactFileId(args.fileId as string)}`
         );
-        const { authInfo } = extra;
-        ensureUserAuthenticated(authInfo);
-        const logger = getLogger();
-        const rl = checkRateLimitedResponse(authInfo, span);
-        if (rl) return rl;
-        try {
-          const result = await extract({
-            token: authInfo!.token,
-            fileId: args.fileId,
-            projectId: args.projectId,
-            configurationId: args.configurationId,
-          });
-          logger.info(`Successfully extracted ${redactFileId(args.fileId)}`);
-          span.end();
-          return {
-            content: [
-              {
-                type: 'text',
-                text: result,
-              },
-            ],
-          } as {
-            content: { type: 'text'; text: string }[];
-          };
-        } catch (err) {
-          logger.error(`An error occurred while extracting data: ${err}`);
-          span.setAttribute('tool.error', true);
-          span.end();
-          throw err;
-        }
-      });
-    }
-  );
+        span.end();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: result,
+            },
+          ],
+        } as {
+          content: { type: 'text'; text: string }[];
+        };
+      } catch (err) {
+        logger.error(`An error occurred while extracting data: ${err}`);
+        span.setAttribute('tool.error', true);
+        span.end();
+        throw err;
+      }
+    });
+  });
 }
 
 // =====================


### PR DESCRIPTION
## Overview

Adds support for binding a saved LlamaCloud configuration ID to the `extract`, `classify`, and `split` MCP tools via dedicated routes, so clients don't have to pass categories / extraction schemas on every call.

## Changes

**`lib/business/llamaparse.ts`**
- `classifyFile` and `splitFile` now accept an optional `configurationId`. When provided, the underlying LlamaCloud call uses `configuration_id` instead of inline `configuration`; `categories` becomes optional. Throws if neither is supplied.
- `extract` already accepted `configurationId` — unchanged.

**`lib/mcp/tools/tools.ts`**
- `registerClassifyFileTool`, `registerSplitFileTool`, and `registerExtractFileTool` now take an optional `fixedConfigurationId` (same pattern as `fixedIndexId` on the index tools). When set, the config-specific inputs (`categories`, `mode`, `allowUncategorized`, `configurationId`) are dropped from the tool schema and the bound config id is injected automatically.
- Aggregate `registerLlamaParseTools` is unchanged, so `/mcp`, `/extract/mcp`, `/classify/mcp`, `/split/mcp` behave exactly as before.

**New routes** (mirroring `/index/[indexId]/mcp`):
- `app/extract/[configId]/mcp/route.ts`
- `app/classify/[configId]/mcp/route.ts`
- `app/split/[configId]/mcp/route.ts`

Each builds a fresh handler per request (no memoization — `configId` is user-supplied and unbounded) and pre-binds the config id to the relevant tool.

## Usage

```
POST /extract/<configId>/mcp    → extractFile({ fileId })
POST /classify/<configId>/mcp   → classifyFile({ fileId })
POST /split/<configId>/mcp      → splitFile({ fileId })
```
