### PR TITLE
feat: add liteparse parsing and complexity estimation functionalities to MCP

### DIFF
--- a/app/parse/mcp/route.ts
+++ b/app/parse/mcp/route.ts
@@ -4,16 +4,20 @@ import {
   registerUploadFileByUrlTool,
   registerGetUserProjectsTool,
   registerParseFileTool,
+  registerLitIsComplexTool,
+  registerLitParseTool,
 } from '@/lib/mcp/tools/tools';
 
 // Parse-only MCP server. Endpoint: /parse/mcp
-// Includes parseFile, the file upload helpers it needs, and getUserProjects.
+// Includes parseFile, parseFileWithLiteParse, estimateFileComplexity, the file upload helpers it needs, and getUserProjects.
 const authHandler = buildMcpRouteHandler(
   (server) => {
     registerGetUserProjectsTool(server);
     registerGetUploadUrlTool(server);
     registerUploadFileByUrlTool(server);
     registerParseFileTool(server);
+    registerLitIsComplexTool(server);
+    registerLitParseTool(server);
   },
   '/parse',
   {

--- a/lib/business/liteparse.ts
+++ b/lib/business/liteparse.ts
@@ -1,0 +1,126 @@
+import type { LiteParse as LiteParseType } from '@llamaindex/liteparse'
+import LlamaCloud from '@llamaindex/llama-cloud'
+
+// Lazy loader so a native-module load failure doesn't crash the whole SSR bundle
+let _LiteParseCtor: typeof LiteParseType | null = null
+async function getLiteParse() {
+  if (!_LiteParseCtor) {
+    const mod = await import('@llamaindex/liteparse')
+    _LiteParseCtor = mod.LiteParse
+  }
+  return _LiteParseCtor
+}
+
+const reasonsToTier: Record<
+  string,
+  'agentic' | 'agentic_plus' | 'cost_effective'
+> = {
+  'no-text': 'cost_effective',
+  scanned: 'agentic',
+  'sparse-text': 'agentic',
+  'embedded-images': 'agentic',
+  garbled: 'agentic_plus',
+  'vector-text': 'agentic_plus',
+}
+
+// (previous top-level `const lit = new LiteParse(...)` moved to lazy init inside handler)
+
+const tierRank = { cost_effective: 0, agentic: 1, agentic_plus: 2 } as const
+
+function compareTier(
+  current: keyof typeof tierRank,
+  requested: keyof typeof tierRank,
+) {
+  return tierRank[current] >= tierRank[requested] ? current : requested
+}
+
+export async function getFile(client: LlamaCloud, fileId: string): Promise<Buffer> {
+  const presigned_url = await client.files.get(fileId);
+  const response = await fetch(presigned_url.url);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Could not fetch the file associated with the provided ID. Status code: ${response.status}; Error detail: ${text}`)
+  }
+  const fileBlob = await response.arrayBuffer();
+  return Buffer.from(fileBlob)
+}
+
+export async function isComplex(
+  {
+    authToken,
+    fileId,
+  }: {
+    authToken: string,
+    fileId: string,
+  }
+) {
+  const client = new LlamaCloud({
+    apiKey: authToken,
+    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+  });
+  const Liteparse = await getLiteParse();
+  const lit = new Liteparse({ ocrEnabled: false, quiet: true, numWorkers: 1 });
+  const buf = await getFile(client, fileId);
+  const isComplex = await lit.isComplex(buf);
+  const pageComplexity: {
+    liteparse: number[]
+    costEffective: number[]
+    agentic: number[]
+    agenticPlus: number[]
+  } = {
+    liteparse: [],
+    costEffective: [],
+    agentic: [],
+    agenticPlus: [],
+  }
+  for (const p of isComplex) {
+    if (!p.needsOcr) {
+      pageComplexity.liteparse.push(p.pageNumber)
+    } else {
+      let tier: 'agentic' | 'agentic_plus' | 'cost_effective' =
+        'cost_effective'
+      for (const r of p.reasons) {
+        tier = compareTier(tier, reasonsToTier[r])
+      }
+      switch (tier) {
+        case 'agentic':
+          pageComplexity.agentic.push(p.pageNumber)
+          break
+        case 'agentic_plus':
+          pageComplexity.agenticPlus.push(p.pageNumber)
+          break
+        default:
+          pageComplexity.costEffective.push(p.pageNumber)
+          break
+      }
+    }
+  }
+  return pageComplexity
+}
+
+export async function litParse({
+  authToken,
+  fileId,
+  pages = undefined,
+  markdown = true,
+  includeJson = false,
+}: {
+  authToken: string,
+  fileId: string,
+  pages?: number[] | undefined,
+  markdown?: boolean,
+  includeJson?: boolean,
+}) {
+  const client = new LlamaCloud({
+    apiKey: authToken,
+    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+  });
+  const Liteparse = await getLiteParse();
+  const lit = new Liteparse({ ocrEnabled: false, quiet: true, numWorkers: 1, outputFormat: markdown ? "markdown" : "text", targetPages: pages ? pages.map((p) => p.toString()).join(",") : undefined });
+  const buf = await getFile(client, fileId);
+  const parsed = await lit.parse(buf);
+  if (includeJson) {
+    return { pages: parsed.pages, text: parsed.text }
+  }
+  return { pages: null, text: parsed.text }
+}

--- a/lib/business/liteparse.ts
+++ b/lib/business/liteparse.ts
@@ -1,14 +1,14 @@
-import type { LiteParse as LiteParseType } from '@llamaindex/liteparse'
-import LlamaCloud from '@llamaindex/llama-cloud'
+import type { LiteParse as LiteParseType } from '@llamaindex/liteparse';
+import LlamaCloud from '@llamaindex/llama-cloud';
 
 // Lazy loader so a native-module load failure doesn't crash the whole SSR bundle
-let _LiteParseCtor: typeof LiteParseType | null = null
+let _LiteParseCtor: typeof LiteParseType | null = null;
 async function getLiteParse() {
   if (!_LiteParseCtor) {
-    const mod = await import('@llamaindex/liteparse')
-    _LiteParseCtor = mod.LiteParse
+    const mod = await import('@llamaindex/liteparse');
+    _LiteParseCtor = mod.LiteParse;
   }
-  return _LiteParseCtor
+  return _LiteParseCtor;
 }
 
 const reasonsToTier: Record<
@@ -21,39 +21,42 @@ const reasonsToTier: Record<
   'embedded-images': 'agentic',
   garbled: 'agentic_plus',
   'vector-text': 'agentic_plus',
-}
+};
 
 // (previous top-level `const lit = new LiteParse(...)` moved to lazy init inside handler)
 
-const tierRank = { cost_effective: 0, agentic: 1, agentic_plus: 2 } as const
+const tierRank = { cost_effective: 0, agentic: 1, agentic_plus: 2 } as const;
 
 function compareTier(
   current: keyof typeof tierRank,
-  requested: keyof typeof tierRank,
+  requested: keyof typeof tierRank
 ) {
-  return tierRank[current] >= tierRank[requested] ? current : requested
+  return tierRank[current] >= tierRank[requested] ? current : requested;
 }
 
-export async function getFile(client: LlamaCloud, fileId: string): Promise<Buffer> {
+export async function getFile(
+  client: LlamaCloud,
+  fileId: string
+): Promise<Buffer> {
   const presigned_url = await client.files.get(fileId);
   const response = await fetch(presigned_url.url);
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Could not fetch the file associated with the provided ID. Status code: ${response.status}; Error detail: ${text}`)
+    throw new Error(
+      `Could not fetch the file associated with the provided ID. Status code: ${response.status}; Error detail: ${text}`
+    );
   }
   const fileBlob = await response.arrayBuffer();
-  return Buffer.from(fileBlob)
+  return Buffer.from(fileBlob);
 }
 
-export async function isComplex(
-  {
-    authToken,
-    fileId,
-  }: {
-    authToken: string,
-    fileId: string,
-  }
-) {
+export async function isComplex({
+  authToken,
+  fileId,
+}: {
+  authToken: string;
+  fileId: string;
+}) {
   const client = new LlamaCloud({
     apiKey: authToken,
     baseURL: process.env.LLAMA_CLOUD_BASE_URL,
@@ -63,39 +66,39 @@ export async function isComplex(
   const buf = await getFile(client, fileId);
   const isComplex = await lit.isComplex(buf);
   const pageComplexity: {
-    liteparse: number[]
-    costEffective: number[]
-    agentic: number[]
-    agenticPlus: number[]
+    liteparse: number[];
+    costEffective: number[];
+    agentic: number[];
+    agenticPlus: number[];
   } = {
     liteparse: [],
     costEffective: [],
     agentic: [],
     agenticPlus: [],
-  }
+  };
   for (const p of isComplex) {
     if (!p.needsOcr) {
-      pageComplexity.liteparse.push(p.pageNumber)
+      pageComplexity.liteparse.push(p.pageNumber);
     } else {
       let tier: 'agentic' | 'agentic_plus' | 'cost_effective' =
-        'cost_effective'
+        'cost_effective';
       for (const r of p.reasons) {
-        tier = compareTier(tier, reasonsToTier[r])
+        tier = compareTier(tier, reasonsToTier[r]);
       }
       switch (tier) {
         case 'agentic':
-          pageComplexity.agentic.push(p.pageNumber)
-          break
+          pageComplexity.agentic.push(p.pageNumber);
+          break;
         case 'agentic_plus':
-          pageComplexity.agenticPlus.push(p.pageNumber)
-          break
+          pageComplexity.agenticPlus.push(p.pageNumber);
+          break;
         default:
-          pageComplexity.costEffective.push(p.pageNumber)
-          break
+          pageComplexity.costEffective.push(p.pageNumber);
+          break;
       }
     }
   }
-  return pageComplexity
+  return pageComplexity;
 }
 
 export async function litParse({
@@ -105,22 +108,28 @@ export async function litParse({
   markdown = true,
   includeJson = false,
 }: {
-  authToken: string,
-  fileId: string,
-  pages?: number[] | undefined,
-  markdown?: boolean,
-  includeJson?: boolean,
+  authToken: string;
+  fileId: string;
+  pages?: number[] | undefined;
+  markdown?: boolean;
+  includeJson?: boolean;
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
     baseURL: process.env.LLAMA_CLOUD_BASE_URL,
   });
   const Liteparse = await getLiteParse();
-  const lit = new Liteparse({ ocrEnabled: false, quiet: true, numWorkers: 1, outputFormat: markdown ? "markdown" : "text", targetPages: pages ? pages.map((p) => p.toString()).join(",") : undefined });
+  const lit = new Liteparse({
+    ocrEnabled: false,
+    quiet: true,
+    numWorkers: 1,
+    outputFormat: markdown ? 'markdown' : 'text',
+    targetPages: pages ? pages.map((p) => p.toString()).join(',') : undefined,
+  });
   const buf = await getFile(client, fileId);
   const parsed = await lit.parse(buf);
   if (includeJson) {
-    return { pages: parsed.pages, text: parsed.text }
+    return { pages: parsed.pages, text: parsed.text };
   }
-  return { pages: null, text: parsed.text }
+  return { pages: null, text: parsed.text };
 }

--- a/lib/business/liteparse.ts
+++ b/lib/business/liteparse.ts
@@ -11,10 +11,62 @@ async function getLiteParse() {
   return _LiteParseCtor;
 }
 
-const reasonsToTier: Record<
-  string,
-  'agentic' | 'agentic_plus' | 'cost_effective'
-> = {
+type Tier = 'cost_effective' | 'agentic' | 'agentic_plus';
+
+const tierRank: Record<Tier, number> = {
+  cost_effective: 0,
+  agentic: 1,
+  agentic_plus: 2,
+};
+
+function maxTier(a: Tier, b: Tier): Tier {
+  return tierRank[a] >= tierRank[b] ? a : b;
+}
+
+interface ComplexityReasonInput {
+  reasons: string[];
+  textLength: number;
+  textCoverage: number;
+  imageCoverage: number;
+  largestImageCoverage: number;
+  imageBlockCount: number;
+  fullPageImage: boolean;
+  uncoveredVectorArea: number | null;
+  isGarbled: boolean;
+  pageArea: number;
+  layout?: {
+    columnCount: number;
+    ruledTableCount: number;
+    ruledTableCoverage: number;
+    textTableRunCount: number;
+    figureCount: number;
+    figureCoverage: number;
+    isComplex: boolean;
+    reasons: string[];
+  } | null;
+}
+
+// Thresholds tuned as separate constants so you can move them without
+// touching the scoring logic.
+const THRESH = {
+  // sparse-text: below this text_coverage, treat as "very sparse" (harder)
+  verySparseTextCoverage: 0.05,
+  // vector-text: uncovered vector area, in pt^2, that indicates "most of
+  // the page is vector text" rather than a stray logo/watermark
+  heavyVectorAreaPt2: 20000,
+  // embedded-images: many small figures interleaved with text is harder to
+  // reconstruct than one dominant image
+  manyImageBlocks: 3,
+  // layout: dense-graphics or multiple layout reasons firing together
+  denseGraphicsCoverage: 0.35,
+} as const;
+
+/**
+ * Base tier a single reason implies on its own, ignoring magnitude.
+ * Kept as a floor so an unknown/new reason variant still gets a sane
+ * default (agentic) instead of silently mapping to cost_effective.
+ */
+const reasonFloor: Record<string, Tier> = {
   'no-text': 'cost_effective',
   scanned: 'agentic',
   'sparse-text': 'agentic',
@@ -23,15 +75,120 @@ const reasonsToTier: Record<
   'vector-text': 'agentic_plus',
 };
 
-// (previous top-level `const lit = new LiteParse(...)` moved to lazy init inside handler)
+function tierForReason(reason: string, p: ComplexityReasonInput): Tier {
+  const floor = reasonFloor[reason] ?? 'agentic'; // unknown reasons: be conservative, not cheap
 
-const tierRank = { cost_effective: 0, agentic: 1, agentic_plus: 2 } as const;
+  switch (reason) {
+    case 'sparse-text':
+      // Thin captions on a figure page vs. genuinely almost-empty text:
+      // the latter behaves more like a scan and deserves agentic_plus if
+      // there's also no full-page image to explain the sparseness (i.e.
+      // it's not just "scan with some OCR'd captions").
+      if (p.textCoverage < THRESH.verySparseTextCoverage && !p.fullPageImage) {
+        return 'agentic_plus';
+      }
+      return floor;
 
-function compareTier(
-  current: keyof typeof tierRank,
-  requested: keyof typeof tierRank
-) {
-  return tierRank[current] >= tierRank[requested] ? current : requested;
+    case 'embedded-images':
+      // One dominant image (e.g. a chart taking up half the page) is
+      // "agentic"-shaped. Several smaller images interleaved with text is
+      // harder to get reading order right on.
+      if (
+        p.imageBlockCount >= THRESH.manyImageBlocks &&
+        p.imageCoverage > p.largestImageCoverage * 1.5
+      ) {
+        return 'agentic_plus';
+      }
+      return floor;
+
+    case 'vector-text':
+      if (
+        p.uncoveredVectorArea !== null &&
+        p.uncoveredVectorArea >= THRESH.heavyVectorAreaPt2
+      ) {
+        return 'agentic_plus'; // already the floor, but explicit for clarity
+      }
+      return floor;
+
+    case 'garbled':
+      // Garbled text alongside substantial real text coverage suggests a
+      // partial cmap failure (some usable structure survives) rather than
+      // full corruption — still agentic_plus per your floor, but you could
+      // soften this if you find it's over-escalating in practice.
+      return floor;
+
+    default:
+      return floor;
+  }
+}
+
+/**
+ * Compounding: multiple independent reasons firing at once (even if each
+ * individually only implies 'agentic') signals a page that's hard in more
+ * than one dimension. Escalate once the reason count crosses a threshold.
+ */
+function compoundingEscalation(p: ComplexityReasonInput, base: Tier): Tier {
+  if (p.reasons.length >= 3 && base === 'agentic') {
+    return 'agentic_plus';
+  }
+  return base;
+}
+
+/**
+ * Layout signals are orthogonal to needs_ocr but still inform tier choice:
+ * a page that needs no OCR at all but has multi-column + table structure
+ * can still trip up a cost_effective single-pass extractor.
+ */
+function layoutEscalation(p: ComplexityReasonInput, base: Tier): Tier {
+  if (!p.layout) return base;
+  const { columnCount, ruledTableCoverage, figureCoverage, reasons } = p.layout;
+
+  let tier = base;
+
+  // Table structure is one of the harder things to reconstruct faithfully;
+  // a lot of ruled-table area pushes towards agentic_plus regardless of
+  // OCR reasons.
+  if (ruledTableCoverage > 0.3) {
+    tier = maxTier(tier, 'agentic_plus');
+  } else if (reasons.includes('table-likely')) {
+    tier = maxTier(tier, 'agentic');
+  }
+
+  if (columnCount >= 3) {
+    tier = maxTier(tier, 'agentic_plus');
+  } else if (columnCount === 2) {
+    tier = maxTier(tier, 'agentic');
+  }
+
+  if (figureCoverage >= THRESH.denseGraphicsCoverage) {
+    tier = maxTier(tier, 'agentic_plus');
+  }
+
+  // Multiple layout reasons compounding, same idea as OCR-reason compounding.
+  if (reasons.length >= 2) {
+    tier = maxTier(tier, base === 'cost_effective' ? 'agentic' : tier);
+  }
+
+  return tier;
+}
+
+export function classifyPageTier(
+  p: ComplexityReasonInput,
+  includeLayout: boolean
+): Tier {
+  if (p.reasons.length === 0 && !(p.layout?.isComplex ?? false)) {
+    return 'cost_effective';
+  }
+
+  let tier: Tier = 'cost_effective';
+  for (const reason of p.reasons) {
+    tier = maxTier(tier, tierForReason(reason, p));
+  }
+  tier = compoundingEscalation(p, tier);
+  if (includeLayout) {
+    tier = layoutEscalation(p, tier);
+  }
+  return tier;
 }
 
 export async function getFile(
@@ -53,51 +210,79 @@ export async function getFile(
 export async function isComplex({
   authToken,
   fileId,
+  includeLayout = false,
 }: {
   authToken: string;
   fileId: string;
+  includeLayout?: boolean;
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
     baseURL: process.env.LLAMA_CLOUD_BASE_URL,
   });
   const Liteparse = await getLiteParse();
-  const lit = new Liteparse({ ocrEnabled: false, quiet: true, numWorkers: 1 });
+  const lit = new Liteparse({
+    ocrEnabled: false,
+    quiet: true,
+    numWorkers: 1,
+  });
   const buf = await getFile(client, fileId);
-  const isComplex = await lit.isComplex(buf);
+  const pages = await lit.isComplex(buf);
+
   const pageComplexity: {
     liteparse: number[];
     costEffective: number[];
     agentic: number[];
     agenticPlus: number[];
-  } = {
-    liteparse: [],
-    costEffective: [],
-    agentic: [],
-    agenticPlus: [],
-  };
-  for (const p of isComplex) {
-    if (!p.needsOcr) {
+  } = { liteparse: [], costEffective: [], agentic: [], agenticPlus: [] };
+
+  for (const p of pages) {
+    if (!p.needsOcr && !(p.layout?.isComplex ?? false)) {
       pageComplexity.liteparse.push(p.pageNumber);
-    } else {
-      let tier: 'agentic' | 'agentic_plus' | 'cost_effective' =
-        'cost_effective';
-      for (const r of p.reasons) {
-        tier = compareTier(tier, reasonsToTier[r]);
-      }
-      switch (tier) {
-        case 'agentic':
-          pageComplexity.agentic.push(p.pageNumber);
-          break;
-        case 'agentic_plus':
-          pageComplexity.agenticPlus.push(p.pageNumber);
-          break;
-        default:
-          pageComplexity.costEffective.push(p.pageNumber);
-          break;
-      }
+      continue;
+    }
+
+    const tier = classifyPageTier(
+      {
+        reasons: p.reasons,
+        textLength: p.textLength,
+        textCoverage: p.textCoverage,
+        imageCoverage: p.imageCoverage,
+        largestImageCoverage: p.largestImageCoverage,
+        imageBlockCount: p.imageBlockCount,
+        fullPageImage: p.fullPageImage,
+        uncoveredVectorArea: p.uncoveredVectorArea ?? null,
+        isGarbled: p.isGarbled,
+        pageArea: p.pageArea,
+        layout: p.layout
+          ? {
+              columnCount: p.layout.columnCount,
+              ruledTableCount: p.layout.ruledTableCount,
+              ruledTableCoverage: p.layout.ruledTableCoverage,
+              textTableRunCount: p.layout.textTableRunCount,
+              figureCount: p.layout.figureCount,
+              figureCoverage: p.layout.figureCoverage,
+              isComplex: p.layout.isComplex,
+              reasons: p.layout.reasons,
+            }
+          : null,
+      },
+      includeLayout
+    );
+
+    switch (tier) {
+      case 'agentic':
+        pageComplexity.agentic.push(p.pageNumber);
+        break;
+      case 'agentic_plus':
+        pageComplexity.agenticPlus.push(p.pageNumber);
+        break;
+      default:
+        pageComplexity.costEffective.push(p.pageNumber);
+        break;
     }
   }
+
   return pageComplexity;
 }
 

--- a/lib/business/llamaparse.ts
+++ b/lib/business/llamaparse.ts
@@ -89,7 +89,9 @@ export async function parseFile({
     project_id: projectId,
     expand,
     page_ranges: {
-      target_pages: pages ? pages.map((p) => p.toString()).join(",") : undefined
+      target_pages: pages
+        ? pages.map((p) => p.toString()).join(',')
+        : undefined,
     },
   });
   const parsingResult: ParsingResult = {};

--- a/lib/business/llamaparse.ts
+++ b/lib/business/llamaparse.ts
@@ -67,6 +67,7 @@ export async function parseFile({
   version = undefined,
   markdown = true,
   projectId = undefined,
+  pages = undefined,
 }: {
   authToken: string;
   fileId: string;
@@ -74,6 +75,7 @@ export async function parseFile({
   version?: undefined | string;
   markdown?: boolean;
   projectId?: string | undefined;
+  pages?: number[] | undefined;
 }): Promise<ParsingResult> {
   const client = new LlamaCloud({
     apiKey: authToken,
@@ -86,6 +88,9 @@ export async function parseFile({
     file_id: fileId,
     project_id: projectId,
     expand,
+    page_ranges: {
+      target_pages: pages ? pages.map((p) => p.toString()).join(",") : undefined
+    },
   });
   const parsingResult: ParsingResult = {};
   if (markdown) {

--- a/lib/mcp/tools/tools.ts
+++ b/lib/mcp/tools/tools.ts
@@ -452,6 +452,12 @@ export function registerLitIsComplexTool(server: McpServer) {
         .describe(
           'ID of the file whose parsing complexity you want to estimate.'
         ),
+      includeLayout: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether or not to include layout signals in the complexity estimation. Defaults to false.'
+        ),
     },
     async (args, extra) => {
       return tracer.startActiveSpan(
@@ -467,6 +473,7 @@ export function registerLitIsComplexTool(server: McpServer) {
             const result = await isComplex({
               authToken: authInfo!.token,
               fileId: args.fileId,
+              includeLayout: args.includeLayout ?? false,
             });
             logger.info(
               `Successfully parsed ${redactFileId(args.fileId)} with LiteParse`

--- a/lib/mcp/tools/tools.ts
+++ b/lib/mcp/tools/tools.ts
@@ -21,6 +21,7 @@ import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import z from 'zod';
 import { randomBytes } from 'node:crypto';
 import { getKVStore } from '@/lib/business/kv';
+import { isComplex, litParse } from '@/lib/business/liteparse';
 
 const tracer = trace.getTracer('mcp-tools');
 
@@ -284,7 +285,7 @@ export function registerGetUserProjectsTool(server: McpServer) {
 export function registerParseFileTool(server: McpServer) {
   server.tool(
     'parseFile',
-    'Parse a file providing its file ID, retrieving markdown or plain text content of the file. Use with file IDs obtained with the uploadFileChunk tool or that the user provided',
+    'Parse a file providing its file ID, retrieving markdown or plain text content of the file. Use with file IDs obtained with the getUploadUrl/uploadFileByUrl tool or that the user provided',
     {
       fileId: z
         .string()
@@ -307,6 +308,7 @@ export function registerParseFileTool(server: McpServer) {
         .describe(
           'Whether to extract markdown or plain text. Defaults to true (extract markdown).'
         ),
+      pages: z.array(z.number()).optional().describe("Specific pages to limit the parsing operation to"),
       projectId: z
         .string()
         .optional()
@@ -332,6 +334,7 @@ export function registerParseFileTool(server: McpServer) {
             version: args.version,
             markdown: args.markdown,
             projectId: args.projectId,
+            pages: args.pages
           });
           logger.info(`Successfully parsed ${redactFileId(args.fileId)}`);
           span.end();
@@ -355,6 +358,107 @@ export function registerParseFileTool(server: McpServer) {
       });
     }
   );
+}
+
+// =====================
+// LiteParse tool
+// =====================
+
+export function registerLitParseTool(server: McpServer) {
+  server.tool(
+    'parseWithLiteParse',
+    'Parse a file with LiteParse, a fast, in-process parser that does not consume credits from the LlamaParse Platform. The tool needs a file ID obtained with the getUploadUrl/uploadFileByUrl tool or provided by the user',
+    {
+      fileId: z.string().describe("ID of the file to parse."),
+      pages: z.array(z.number()).optional().describe("Page numbers to limit the parsing operation to. 1-based."),
+      markdown: z.boolean().optional().describe("Whether the output text should be markdown-formatted or plain text"),
+      includeJson: z.boolean().optional().describe("Whether to include the JSON array of pages (with bboxes) in the parse result")
+    },
+    async (args, extra) => {
+      return tracer.startActiveSpan('tool.parseWithLiteParse', async (span) => {
+        span.setAttribute('tool.file_id', redactFileId(args.fileId));
+        if (typeof args.markdown !== "undefined") span.setAttribute('tool.markdown', args.markdown);
+        if (typeof args.includeJson !== "undefined") span.setAttribute('tool.include_json', args.includeJson);
+        if (args.pages) span.setAttribute('tool.version', args.pages.map((p) => p.toString).join(", "));
+        const { authInfo } = extra;
+        ensureUserAuthenticated(authInfo);
+        const logger = getLogger();
+        const rl = checkRateLimitedResponse(authInfo, span);
+        if (rl) return rl;
+        try {
+          const result = await litParse({
+            authToken: authInfo!.token,
+            fileId: args.fileId,
+            markdown: args.markdown,
+            pages: args.pages,
+            includeJson: args.includeJson
+          });
+          logger.info(`Successfully parsed ${redactFileId(args.fileId)} with LiteParse`);
+          span.end();
+          return {
+            content: [
+              {
+                type: 'text',
+                text:
+                  JSON.stringify(result, undefined, 2),
+              },
+            ],
+          } as {
+            content: { type: 'text'; text: string }[];
+          };
+        } catch (err) {
+          logger.error(`An error occurred while parsing with LiteParse: ${err}`);
+          span.setAttribute('tool.error', true);
+          span.end();
+          throw err;
+        }
+      });
+    },
+  )
+}
+
+export function registerLitIsComplexTool(server: McpServer) {
+  server.tool(
+    'estimateFileComplexity',
+    'Estimate the parsing complexity of a file (providing its file ID) using LiteParse. Returns a JSON object mapping each page with the LlamaParse tier it should be parsed with (or if you should use LiteParse), based on the parsing complexity and the need for OCR. Use in combination with parseFile and parseWithLiteParse. The tool needs a file ID obtained with the getUploadUrl/uploadFileByUrl tool or provided by the user',
+    {
+      fileId: z.string().describe("ID of the file whose parsing complexity you want to estimate."),
+    },
+    async (args, extra) => {
+      return tracer.startActiveSpan('tool.estimateFileComplexity', async (span) => {
+        span.setAttribute('tool.file_id', redactFileId(args.fileId));
+        const { authInfo } = extra;
+        ensureUserAuthenticated(authInfo);
+        const logger = getLogger();
+        const rl = checkRateLimitedResponse(authInfo, span);
+        if (rl) return rl;
+        try {
+          const result = await isComplex({
+            authToken: authInfo!.token,
+            fileId: args.fileId,
+          });
+          logger.info(`Successfully parsed ${redactFileId(args.fileId)} with LiteParse`);
+          span.end();
+          return {
+            content: [
+              {
+                type: 'text',
+                text:
+                  JSON.stringify(result, undefined, 2),
+              },
+            ],
+          } as {
+            content: { type: 'text'; text: string }[];
+          };
+        } catch (err) {
+          logger.error(`An error occurred while estimating the file complexity with LiteParse: ${err}`);
+          span.setAttribute('tool.error', true);
+          span.end();
+          throw err;
+        }
+      });
+    },
+  )
 }
 
 // =====================
@@ -395,7 +499,7 @@ export function registerClassifyFileTool(
   }
   const description = fixedConfigurationId
     ? `Classify a file using the saved classify configuration ${fixedConfigurationId}. Provide the file ID (as returned by the upload tool or supplied by the user); the categories are pulled from the saved configuration.`
-    : 'Classify a file (based on specific categories) providing its file ID. Use with file IDs obtained with the uploadFileChunk tool or that the user provided';
+    : 'Classify a file (based on specific categories) providing its file ID. Use with file IDs obtained with the getUploadUrl/uploadFileByUrl tool or that the user provided';
   server.tool('classifyFile', description, schema, async (args, extra) => {
     return tracer.startActiveSpan('tool.classifyFile', async (span) => {
       span.setAttribute('tool.file_id', redactFileId(args.fileId as string));
@@ -480,7 +584,7 @@ export function registerSplitFileTool(
   }
   const description = fixedConfigurationId
     ? `Split a file into category-based segments using the saved split configuration ${fixedConfigurationId}. Provide the file ID (as returned by the upload tool or supplied by the user); the categories and splitting strategy are pulled from the saved configuration.`
-    : 'Split a file into category-based segments providing its file ID. Use with file IDs obtained with the uploadFileChunk tool or that the user provided';
+    : 'Split a file into category-based segments providing its file ID. Use with file IDs obtained with the getUploadUrl/uploadFileByUrl tool or that the user provided';
   server.tool('splitFile', description, schema, async (args, extra) => {
     return tracer.startActiveSpan('tool.splitFile', async (span) => {
       span.setAttribute('tool.file_id', redactFileId(args.fileId as string));
@@ -1088,4 +1192,6 @@ export function registerLlamaParseTools(server: McpServer) {
   registerReadFileFromIndexTool(server);
   registerGrepFileFromIndexTool(server);
   registerRetrieveFromIndexTool(server);
+  registerLitParseTool(server);
+  registerLitIsComplexTool(server);
 }

--- a/lib/mcp/tools/tools.ts
+++ b/lib/mcp/tools/tools.ts
@@ -308,7 +308,10 @@ export function registerParseFileTool(server: McpServer) {
         .describe(
           'Whether to extract markdown or plain text. Defaults to true (extract markdown).'
         ),
-      pages: z.array(z.number()).optional().describe("Specific pages to limit the parsing operation to"),
+      pages: z
+        .array(z.number())
+        .optional()
+        .describe('Specific pages to limit the parsing operation to'),
       projectId: z
         .string()
         .optional()
@@ -334,7 +337,7 @@ export function registerParseFileTool(server: McpServer) {
             version: args.version,
             markdown: args.markdown,
             projectId: args.projectId,
-            pages: args.pages
+            pages: args.pages,
           });
           logger.info(`Successfully parsed ${redactFileId(args.fileId)}`);
           span.end();
@@ -369,17 +372,36 @@ export function registerLitParseTool(server: McpServer) {
     'parseWithLiteParse',
     'Parse a file with LiteParse, a fast, in-process parser that does not consume credits from the LlamaParse Platform. The tool needs a file ID obtained with the getUploadUrl/uploadFileByUrl tool or provided by the user',
     {
-      fileId: z.string().describe("ID of the file to parse."),
-      pages: z.array(z.number()).optional().describe("Page numbers to limit the parsing operation to. 1-based."),
-      markdown: z.boolean().optional().describe("Whether the output text should be markdown-formatted or plain text"),
-      includeJson: z.boolean().optional().describe("Whether to include the JSON array of pages (with bboxes) in the parse result")
+      fileId: z.string().describe('ID of the file to parse.'),
+      pages: z
+        .array(z.number())
+        .optional()
+        .describe('Page numbers to limit the parsing operation to. 1-based.'),
+      markdown: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether the output text should be markdown-formatted or plain text'
+        ),
+      includeJson: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether to include the JSON array of pages (with bboxes) in the parse result'
+        ),
     },
     async (args, extra) => {
       return tracer.startActiveSpan('tool.parseWithLiteParse', async (span) => {
         span.setAttribute('tool.file_id', redactFileId(args.fileId));
-        if (typeof args.markdown !== "undefined") span.setAttribute('tool.markdown', args.markdown);
-        if (typeof args.includeJson !== "undefined") span.setAttribute('tool.include_json', args.includeJson);
-        if (args.pages) span.setAttribute('tool.version', args.pages.map((p) => p.toString).join(", "));
+        if (typeof args.markdown !== 'undefined')
+          span.setAttribute('tool.markdown', args.markdown);
+        if (typeof args.includeJson !== 'undefined')
+          span.setAttribute('tool.include_json', args.includeJson);
+        if (args.pages)
+          span.setAttribute(
+            'tool.version',
+            args.pages.map((p) => p.toString).join(', ')
+          );
         const { authInfo } = extra;
         ensureUserAuthenticated(authInfo);
         const logger = getLogger();
@@ -391,30 +413,33 @@ export function registerLitParseTool(server: McpServer) {
             fileId: args.fileId,
             markdown: args.markdown,
             pages: args.pages,
-            includeJson: args.includeJson
+            includeJson: args.includeJson,
           });
-          logger.info(`Successfully parsed ${redactFileId(args.fileId)} with LiteParse`);
+          logger.info(
+            `Successfully parsed ${redactFileId(args.fileId)} with LiteParse`
+          );
           span.end();
           return {
             content: [
               {
                 type: 'text',
-                text:
-                  JSON.stringify(result, undefined, 2),
+                text: JSON.stringify(result, undefined, 2),
               },
             ],
           } as {
             content: { type: 'text'; text: string }[];
           };
         } catch (err) {
-          logger.error(`An error occurred while parsing with LiteParse: ${err}`);
+          logger.error(
+            `An error occurred while parsing with LiteParse: ${err}`
+          );
           span.setAttribute('tool.error', true);
           span.end();
           throw err;
         }
       });
-    },
-  )
+    }
+  );
 }
 
 export function registerLitIsComplexTool(server: McpServer) {
@@ -422,43 +447,53 @@ export function registerLitIsComplexTool(server: McpServer) {
     'estimateFileComplexity',
     'Estimate the parsing complexity of a file (providing its file ID) using LiteParse. Returns a JSON object mapping each page with the LlamaParse tier it should be parsed with (or if you should use LiteParse), based on the parsing complexity and the need for OCR. Use in combination with parseFile and parseWithLiteParse. The tool needs a file ID obtained with the getUploadUrl/uploadFileByUrl tool or provided by the user',
     {
-      fileId: z.string().describe("ID of the file whose parsing complexity you want to estimate."),
+      fileId: z
+        .string()
+        .describe(
+          'ID of the file whose parsing complexity you want to estimate.'
+        ),
     },
     async (args, extra) => {
-      return tracer.startActiveSpan('tool.estimateFileComplexity', async (span) => {
-        span.setAttribute('tool.file_id', redactFileId(args.fileId));
-        const { authInfo } = extra;
-        ensureUserAuthenticated(authInfo);
-        const logger = getLogger();
-        const rl = checkRateLimitedResponse(authInfo, span);
-        if (rl) return rl;
-        try {
-          const result = await isComplex({
-            authToken: authInfo!.token,
-            fileId: args.fileId,
-          });
-          logger.info(`Successfully parsed ${redactFileId(args.fileId)} with LiteParse`);
-          span.end();
-          return {
-            content: [
-              {
-                type: 'text',
-                text:
-                  JSON.stringify(result, undefined, 2),
-              },
-            ],
-          } as {
-            content: { type: 'text'; text: string }[];
-          };
-        } catch (err) {
-          logger.error(`An error occurred while estimating the file complexity with LiteParse: ${err}`);
-          span.setAttribute('tool.error', true);
-          span.end();
-          throw err;
+      return tracer.startActiveSpan(
+        'tool.estimateFileComplexity',
+        async (span) => {
+          span.setAttribute('tool.file_id', redactFileId(args.fileId));
+          const { authInfo } = extra;
+          ensureUserAuthenticated(authInfo);
+          const logger = getLogger();
+          const rl = checkRateLimitedResponse(authInfo, span);
+          if (rl) return rl;
+          try {
+            const result = await isComplex({
+              authToken: authInfo!.token,
+              fileId: args.fileId,
+            });
+            logger.info(
+              `Successfully parsed ${redactFileId(args.fileId)} with LiteParse`
+            );
+            span.end();
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, undefined, 2),
+                },
+              ],
+            } as {
+              content: { type: 'text'; text: string }[];
+            };
+          } catch (err) {
+            logger.error(
+              `An error occurred while estimating the file complexity with LiteParse: ${err}`
+            );
+            span.setAttribute('tool.error', true);
+            span.end();
+            throw err;
+          }
         }
-      });
-    },
-  )
+      );
+    }
+  );
 }
 
 // =====================

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@workos-inc/authkit-nextjs'],
+  transpilePackages: ['@workos-inc/authkit-nextjs', '@llamaindex/liteparse'],
   outputFileTracingRoot: __dirname,
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@llamaindex/liteparse": "^2.7.0",
     "@llamaindex/llama-cloud": "2.8.0",
     "@modelcontextprotocol/sdk": "1.15.0",
     "@opentelemetry/api": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@llamaindex/liteparse": "^2.7.0",
+    "@llamaindex/liteparse": "^2.8.0",
     "@llamaindex/llama-cloud": "2.8.0",
     "@modelcontextprotocol/sdk": "1.15.0",
     "@opentelemetry/api": "^1.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@llamaindex/liteparse':
+        specifier: ^2.7.0
+        version: 2.7.0
       '@llamaindex/llama-cloud':
         specifier: 2.8.0
         version: 2.8.0
@@ -594,6 +597,46 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@llamaindex/liteparse-darwin-arm64@2.7.0':
+    resolution: {integrity: sha512-gId5/uOD1i8DFx13sAZ8aqH1yOY14QucDH+6cSbF9xSKdlnDogVBZ2zhZEO0EU+rMEHURRD3gdFu2HBBUbbLrQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@llamaindex/liteparse-darwin-x64@2.7.0':
+    resolution: {integrity: sha512-SmUbaxBuahdVVHlRMeKNVNN3ql4adlKDgdNvbAzy1TzkbhS1PI8dj8rcnmBJOFD/3o9yp6q2SapRocv9V/rykQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@llamaindex/liteparse-linux-arm64-gnu@2.7.0':
+    resolution: {integrity: sha512-BDZfpgL3zPUyAoubGVdHSrcF8Apw+QcVljAPHIJR7fV5OKtWXXX9CgiFQyQ1S8i2LHRvwx6oTbHqVD0mC7ChhA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@llamaindex/liteparse-linux-x64-gnu@2.7.0':
+    resolution: {integrity: sha512-zn9gAQtH7nDb9xdNaoGzNS5gUkVvMq4/f3AodGKopxWgYXSjFf2rvwCPbxraoS6Q87DOaJ8a4ggNGzVLYHv3Zg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@llamaindex/liteparse-linux-x64-musl@2.7.0':
+    resolution: {integrity: sha512-aLD/8qd1oPahwWrzO5+Y/5cra9eE4yjVSH2IWmYEYafirRJq1HrkLpLMOcBZvKgbjTnrLLm90+Mnz3u/dpevWw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@llamaindex/liteparse-win32-arm64-msvc@2.7.0':
+    resolution: {integrity: sha512-3aoNQQSAl927Ywi/nUQAdhPEHgnWNeoUOMIcanaqmxc9u/QRm4pmxwFzOrUclIum4JYf/LS/8c3N9Ou8w9OGlw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@llamaindex/liteparse-win32-x64-msvc@2.7.0':
+    resolution: {integrity: sha512-rFDkmM+86mt1YRkWYWMFrfDoHMDzQ31hBRlBy8pR20JAAO05yq9PY5Hod/OuY6qHy2qiHBgs4gcVryWvdJGkow==}
+    cpu: [x64]
+    os: [win32]
+
+  '@llamaindex/liteparse@2.7.0':
+    resolution: {integrity: sha512-GUhiOrSFgiYpqqCMVHP7Knj8tQiMsDozM8VbjoO2orXms/QbUz2jHz4EWdrFfqZGCE23zV7bNfTUD71l8AY0qw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@llamaindex/llama-cloud@2.8.0':
     resolution: {integrity: sha512-L/Bao8ebVZpVwkpig54IlKEaFXYn4YoKhIWXtDqwul4Vxa8y+o9qvJL9qdWhpajrxPsHigTSPHn9C8OR80W+HA==}
@@ -1398,6 +1441,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -4026,6 +4073,39 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@llamaindex/liteparse-darwin-arm64@2.7.0':
+    optional: true
+
+  '@llamaindex/liteparse-darwin-x64@2.7.0':
+    optional: true
+
+  '@llamaindex/liteparse-linux-arm64-gnu@2.7.0':
+    optional: true
+
+  '@llamaindex/liteparse-linux-x64-gnu@2.7.0':
+    optional: true
+
+  '@llamaindex/liteparse-linux-x64-musl@2.7.0':
+    optional: true
+
+  '@llamaindex/liteparse-win32-arm64-msvc@2.7.0':
+    optional: true
+
+  '@llamaindex/liteparse-win32-x64-msvc@2.7.0':
+    optional: true
+
+  '@llamaindex/liteparse@2.7.0':
+    dependencies:
+      commander: 12.1.0
+    optionalDependencies:
+      '@llamaindex/liteparse-darwin-arm64': 2.7.0
+      '@llamaindex/liteparse-darwin-x64': 2.7.0
+      '@llamaindex/liteparse-linux-arm64-gnu': 2.7.0
+      '@llamaindex/liteparse-linux-x64-gnu': 2.7.0
+      '@llamaindex/liteparse-linux-x64-musl': 2.7.0
+      '@llamaindex/liteparse-win32-arm64-msvc': 2.7.0
+      '@llamaindex/liteparse-win32-x64-msvc': 2.7.0
+
   '@llamaindex/llama-cloud@2.8.0': {}
 
   '@modelcontextprotocol/sdk@1.15.0':
@@ -4872,6 +4952,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@11.1.0: {}
+
+  commander@12.1.0: {}
 
   commander@4.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@llamaindex/liteparse':
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.8.0
+        version: 2.8.0
       '@llamaindex/llama-cloud':
         specifier: 2.8.0
         version: 2.8.0
@@ -598,43 +598,43 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@llamaindex/liteparse-darwin-arm64@2.7.0':
-    resolution: {integrity: sha512-gId5/uOD1i8DFx13sAZ8aqH1yOY14QucDH+6cSbF9xSKdlnDogVBZ2zhZEO0EU+rMEHURRD3gdFu2HBBUbbLrQ==}
+  '@llamaindex/liteparse-darwin-arm64@2.8.0':
+    resolution: {integrity: sha512-b6GMRC1s+7iQMvXyeS7Hz3pLU1C0D7tyxXQa1isLEwvTaC5sA+vIsUxc51CT364VAEWdNtx/OifCY83SEfkDdQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@llamaindex/liteparse-darwin-x64@2.7.0':
-    resolution: {integrity: sha512-SmUbaxBuahdVVHlRMeKNVNN3ql4adlKDgdNvbAzy1TzkbhS1PI8dj8rcnmBJOFD/3o9yp6q2SapRocv9V/rykQ==}
+  '@llamaindex/liteparse-darwin-x64@2.8.0':
+    resolution: {integrity: sha512-XTPYt2JGY/ylsDMnhLvngNwt0E/YNiDH8X4B9pWyRrfqbdzNMDphKWxyiLR4lljzT25jwOW6MDPNsU2ew2/o/Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@llamaindex/liteparse-linux-arm64-gnu@2.7.0':
-    resolution: {integrity: sha512-BDZfpgL3zPUyAoubGVdHSrcF8Apw+QcVljAPHIJR7fV5OKtWXXX9CgiFQyQ1S8i2LHRvwx6oTbHqVD0mC7ChhA==}
+  '@llamaindex/liteparse-linux-arm64-gnu@2.8.0':
+    resolution: {integrity: sha512-9fewsJyfzmhXuURZskgsPruXfn1RuQHN7OV7VFwGUrdCULovijpE3DoZU8CJ8FTgI+eTV+7Di4L23lMujhM7aQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@llamaindex/liteparse-linux-x64-gnu@2.7.0':
-    resolution: {integrity: sha512-zn9gAQtH7nDb9xdNaoGzNS5gUkVvMq4/f3AodGKopxWgYXSjFf2rvwCPbxraoS6Q87DOaJ8a4ggNGzVLYHv3Zg==}
+  '@llamaindex/liteparse-linux-x64-gnu@2.8.0':
+    resolution: {integrity: sha512-fl3VgDnkiPXdFY0bPwfFGRFnZaklL8dPYM5T1sIjWkYcJAYxMa13/xsso1Co47SNJSDPzgpaOEYcZpQAu3b0Pg==}
     cpu: [x64]
     os: [linux]
 
-  '@llamaindex/liteparse-linux-x64-musl@2.7.0':
-    resolution: {integrity: sha512-aLD/8qd1oPahwWrzO5+Y/5cra9eE4yjVSH2IWmYEYafirRJq1HrkLpLMOcBZvKgbjTnrLLm90+Mnz3u/dpevWw==}
+  '@llamaindex/liteparse-linux-x64-musl@2.8.0':
+    resolution: {integrity: sha512-zf7R2CSpXhba4G+8H9vut9/OqFwif3HSC/6uhfR2ZusqiwAqd+FOss2g0RHgJjuJej46E/ek/iUiFPiFWMe9Mg==}
     cpu: [x64]
     os: [linux]
 
-  '@llamaindex/liteparse-win32-arm64-msvc@2.7.0':
-    resolution: {integrity: sha512-3aoNQQSAl927Ywi/nUQAdhPEHgnWNeoUOMIcanaqmxc9u/QRm4pmxwFzOrUclIum4JYf/LS/8c3N9Ou8w9OGlw==}
+  '@llamaindex/liteparse-win32-arm64-msvc@2.8.0':
+    resolution: {integrity: sha512-LTgSjjBVe1UcGGMQ67+zK9kzN7gFl8WzXAhWH/WiG9uhhXllyNFdR4Yq0gXCIGjcihcGqtIIBxI57jlD7f80/g==}
     cpu: [arm64]
     os: [win32]
 
-  '@llamaindex/liteparse-win32-x64-msvc@2.7.0':
-    resolution: {integrity: sha512-rFDkmM+86mt1YRkWYWMFrfDoHMDzQ31hBRlBy8pR20JAAO05yq9PY5Hod/OuY6qHy2qiHBgs4gcVryWvdJGkow==}
+  '@llamaindex/liteparse-win32-x64-msvc@2.8.0':
+    resolution: {integrity: sha512-HnAQSXUp/xiAD2/I1RQfrPP2K1u2zdJuc0wODDb7sap/KSGNiRZfRQErj+WeYwkxBRgwI9/e7Rq1vCNn/w3OQw==}
     cpu: [x64]
     os: [win32]
 
-  '@llamaindex/liteparse@2.7.0':
-    resolution: {integrity: sha512-GUhiOrSFgiYpqqCMVHP7Knj8tQiMsDozM8VbjoO2orXms/QbUz2jHz4EWdrFfqZGCE23zV7bNfTUD71l8AY0qw==}
+  '@llamaindex/liteparse@2.8.0':
+    resolution: {integrity: sha512-xAAoSxYJsJPGm9OPvWKZFq4u5O0d1i/7ClgeXfjNhancurif2NZ4NQsQzoxmM9RG5Aa5f9pCFEMGkrRJTw2d/w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -4073,38 +4073,38 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@llamaindex/liteparse-darwin-arm64@2.7.0':
+  '@llamaindex/liteparse-darwin-arm64@2.8.0':
     optional: true
 
-  '@llamaindex/liteparse-darwin-x64@2.7.0':
+  '@llamaindex/liteparse-darwin-x64@2.8.0':
     optional: true
 
-  '@llamaindex/liteparse-linux-arm64-gnu@2.7.0':
+  '@llamaindex/liteparse-linux-arm64-gnu@2.8.0':
     optional: true
 
-  '@llamaindex/liteparse-linux-x64-gnu@2.7.0':
+  '@llamaindex/liteparse-linux-x64-gnu@2.8.0':
     optional: true
 
-  '@llamaindex/liteparse-linux-x64-musl@2.7.0':
+  '@llamaindex/liteparse-linux-x64-musl@2.8.0':
     optional: true
 
-  '@llamaindex/liteparse-win32-arm64-msvc@2.7.0':
+  '@llamaindex/liteparse-win32-arm64-msvc@2.8.0':
     optional: true
 
-  '@llamaindex/liteparse-win32-x64-msvc@2.7.0':
+  '@llamaindex/liteparse-win32-x64-msvc@2.8.0':
     optional: true
 
-  '@llamaindex/liteparse@2.7.0':
+  '@llamaindex/liteparse@2.8.0':
     dependencies:
       commander: 12.1.0
     optionalDependencies:
-      '@llamaindex/liteparse-darwin-arm64': 2.7.0
-      '@llamaindex/liteparse-darwin-x64': 2.7.0
-      '@llamaindex/liteparse-linux-arm64-gnu': 2.7.0
-      '@llamaindex/liteparse-linux-x64-gnu': 2.7.0
-      '@llamaindex/liteparse-linux-x64-musl': 2.7.0
-      '@llamaindex/liteparse-win32-arm64-msvc': 2.7.0
-      '@llamaindex/liteparse-win32-x64-msvc': 2.7.0
+      '@llamaindex/liteparse-darwin-arm64': 2.8.0
+      '@llamaindex/liteparse-darwin-x64': 2.8.0
+      '@llamaindex/liteparse-linux-arm64-gnu': 2.8.0
+      '@llamaindex/liteparse-linux-x64-gnu': 2.8.0
+      '@llamaindex/liteparse-linux-x64-musl': 2.8.0
+      '@llamaindex/liteparse-win32-arm64-msvc': 2.8.0
+      '@llamaindex/liteparse-win32-x64-msvc': 2.8.0
 
   '@llamaindex/llama-cloud@2.8.0': {}
 


### PR DESCRIPTION
Add a `parseWithLiteParse` and `estimateFileComplexity` tool to allow a complexity-based routing approach to parsing.

Still needs file IDs for parsing/complexity estimation.

Also add a `pages` arg so that different pages can be parsed with a different tier 

