### PR TITLE
LI-8474: derive the LlamaCloud API base from an explicit region

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,14 @@ NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/callback
 # Use http://localhost:3000 for local dev
 NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL=http://localhost:3000
 
-# LlamaCloud (optional — overrides the default API base)
-LLAMA_CLOUD_BASE_URL=https://api.cloud.llamaindex.ai
+# LlamaCloud region this deployment serves: `na` (default) or `eu`.
+# Selects the API base URL; `na` -> api.cloud.llamaindex.ai,
+# `eu` -> api.cloud.eu.llamaindex.ai.
+LLAMA_CLOUD_REGION=na
+
+# Optional override of the API base derived from LLAMA_CLOUD_REGION, for local
+# development or staging. It may not point at another region's API.
+# LLAMA_CLOUD_BASE_URL=http://localhost:8000
 
 # Redis — required for the pre-signed upload URL feature
 REDIS_URI=redis://localhost:6379

--- a/__tests__/region.test.ts
+++ b/__tests__/region.test.ts
@@ -1,0 +1,123 @@
+import { getRegion, llamaCloudBaseUrl, regionProfile } from '../lib/region';
+
+const NA_API = 'https://api.cloud.llamaindex.ai';
+const EU_API = 'https://api.cloud.eu.llamaindex.ai';
+
+describe('region', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.LLAMA_CLOUD_REGION;
+    delete process.env.LLAMA_CLOUD_BASE_URL;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getRegion', () => {
+    it('defaults to na when unset', () => {
+      expect(getRegion()).toBe('na');
+    });
+
+    it('defaults to na when empty', () => {
+      process.env.LLAMA_CLOUD_REGION = '';
+      expect(getRegion()).toBe('na');
+    });
+
+    it('reads eu', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      expect(getRegion()).toBe('eu');
+    });
+
+    it('is case- and whitespace-insensitive', () => {
+      process.env.LLAMA_CLOUD_REGION = '  EU ';
+      expect(getRegion()).toBe('eu');
+    });
+
+    it('throws on an unknown region', () => {
+      process.env.LLAMA_CLOUD_REGION = 'apac';
+      expect(() => getRegion()).toThrow(/Invalid LLAMA_CLOUD_REGION "apac"/);
+    });
+  });
+
+  describe('regionProfile', () => {
+    it('describes na', () => {
+      expect(regionProfile()).toEqual({
+        label: 'North America (NA)',
+        apiBaseUrl: NA_API,
+      });
+    });
+
+    it('describes eu', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      expect(regionProfile()).toEqual({
+        label: 'Europe (EU)',
+        apiBaseUrl: EU_API,
+      });
+    });
+  });
+
+  describe('llamaCloudBaseUrl', () => {
+    it('derives the na api base by default', () => {
+      expect(llamaCloudBaseUrl()).toBe(NA_API);
+    });
+
+    it('derives the eu api base in the eu region', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      expect(llamaCloudBaseUrl()).toBe(EU_API);
+    });
+
+    it('honours an override', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = 'http://localhost:8000';
+      expect(llamaCloudBaseUrl()).toBe('http://localhost:8000');
+    });
+
+    it('ignores a blank override', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = '   ';
+      expect(llamaCloudBaseUrl()).toBe(EU_API);
+    });
+
+    it('strips trailing slashes from an override', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = 'http://localhost:8000//';
+      expect(llamaCloudBaseUrl()).toBe('http://localhost:8000');
+    });
+
+    it('allows an override matching the configured region', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
+      expect(llamaCloudBaseUrl()).toBe(EU_API);
+    });
+
+    it('rejects an eu deployment pointed at the na api', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = NA_API;
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /points at the North America \(NA\) API .* but LLAMA_CLOUD_REGION is "eu"/
+      );
+    });
+
+    it('rejects an na deployment pointed at the eu api', () => {
+      process.env.LLAMA_CLOUD_REGION = 'na';
+      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /points at the Europe \(EU\) API .* but LLAMA_CLOUD_REGION is "na"/
+      );
+    });
+
+    it('rejects a cross-region override regardless of trailing path or case', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'https://API.Cloud.LlamaIndex.ai/';
+      expect(() => llamaCloudBaseUrl()).toThrow(/North America \(NA\)/);
+    });
+
+    it('throws on a malformed override', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = 'not-a-url';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /LLAMA_CLOUD_BASE_URL is not a valid URL/
+      );
+    });
+  });
+});

--- a/__tests__/region.test.ts
+++ b/__tests__/region.test.ts
@@ -1,4 +1,9 @@
-import { getRegion, llamaCloudBaseUrl, regionProfile } from '../lib/region';
+import {
+  assertRegionConfig,
+  getRegion,
+  llamaCloudBaseUrl,
+  regionProfile,
+} from '../lib/region';
 
 const NA_API = 'https://api.cloud.llamaindex.ai';
 const EU_API = 'https://api.cloud.eu.llamaindex.ai';
@@ -116,6 +121,36 @@ describe('region', () => {
     it('throws on a malformed override', () => {
       process.env.LLAMA_CLOUD_BASE_URL = 'not-a-url';
       expect(() => llamaCloudBaseUrl()).toThrow(
+        /LLAMA_CLOUD_BASE_URL is not a valid URL/
+      );
+    });
+  });
+
+  describe('assertRegionConfig', () => {
+    it('accepts the default configuration', () => {
+      expect(() => assertRegionConfig()).not.toThrow();
+    });
+
+    it('accepts a consistent eu configuration', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
+      expect(() => assertRegionConfig()).not.toThrow();
+    });
+
+    it('rejects an unknown region', () => {
+      process.env.LLAMA_CLOUD_REGION = 'apac';
+      expect(() => assertRegionConfig()).toThrow(/Invalid LLAMA_CLOUD_REGION/);
+    });
+
+    it('rejects a cross-region base url override', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = NA_API;
+      expect(() => assertRegionConfig()).toThrow(/North America \(NA\)/);
+    });
+
+    it('rejects a malformed base url override', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = 'not-a-url';
+      expect(() => assertRegionConfig()).toThrow(
         /LLAMA_CLOUD_BASE_URL is not a valid URL/
       );
     });

--- a/app/api/upload/[token]/route.ts
+++ b/app/api/upload/[token]/route.ts
@@ -1,6 +1,7 @@
 import { getKVStore } from '@/lib/business/kv';
 import { NextRequest, NextResponse } from 'next/server';
 import LlamaCloud from '@llamaindex/llama-cloud';
+import { llamaCloudBaseUrl } from '@/lib/region';
 
 // @ts-expect-error params is implictly any
 export async function POST(req: NextRequest, { params }) {
@@ -38,7 +39,7 @@ export async function POST(req: NextRequest, { params }) {
   const projectId = req.nextUrl.searchParams.get('project_id') ?? undefined;
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   try {
     const fileObj = await client.files.create({

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,8 @@
 import { registerOTel, OTLPHttpJsonTraceExporter } from '@vercel/otel';
+import { assertRegionConfig } from './lib/region';
 
 export function register() {
+  assertRegionConfig();
   registerOTel({
     serviceName: 'llamaindex-mcp-traces',
     traceExporter: new OTLPHttpJsonTraceExporter({

--- a/lib/business/liteparse.ts
+++ b/lib/business/liteparse.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { LiteParse as LiteParseType } from '@llamaindex/liteparse-wasm';
 import LlamaCloud from '@llamaindex/llama-cloud';
+import { llamaCloudBaseUrl } from '../region';
 
 // Lazy loader: initializes the wasm module once and caches the constructor.
 //
@@ -241,7 +242,7 @@ export async function isComplex({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const Liteparse = await getLiteParse();
   const lit = new Liteparse({
@@ -323,7 +324,7 @@ export async function litParse({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const Liteparse = await getLiteParse();
   const lit = new Liteparse({

--- a/lib/business/llamaparse.ts
+++ b/lib/business/llamaparse.ts
@@ -7,6 +7,7 @@ import {
   SplitResult,
 } from './types';
 import { RetrievalGrepResponse } from '@llamaindex/llama-cloud/resources/beta.js';
+import { llamaCloudBaseUrl } from '../region';
 
 const MaximumWaitingTime: number = 1800 * 1000;
 const MaxDelay: number = 60;
@@ -32,7 +33,7 @@ export async function uploadFile({
 }): Promise<string> {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   let bytes;
   if (typeof fileData === 'string') {
@@ -79,7 +80,7 @@ export async function parseFile({
 }): Promise<ParsingResult> {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const expand = [markdown ? 'markdown_full' : 'text_full'];
   const result = await client.parsing.parse({
@@ -120,7 +121,7 @@ export async function classifyFile({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
 
   if (!configurationId && !categories) {
@@ -196,7 +197,7 @@ export async function splitFile({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
 
   if (!configurationId && !categories) {
@@ -254,7 +255,7 @@ export async function splitFile({
 export async function getProjects(authToken: string): Promise<string[]> {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const projects = await client.projects.list();
   const projectIds = projects.map((p) => p.id);
@@ -274,7 +275,7 @@ export async function generateExtractSchema({
 }): Promise<[string, string]> {
   const client = new LlamaCloud({
     apiKey: token,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const configCreateReq = await client.extract.generateSchema({
     project_id: projectId,
@@ -305,7 +306,7 @@ export async function extract({
 }) {
   const client = new LlamaCloud({
     apiKey: token,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const response = await client.extract.run({
     file_input: fileId,
@@ -344,7 +345,7 @@ export async function listIndexes({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   let pageToken: string | undefined = undefined;
   const indexes: { name: string; indexId: string; description: string }[] = [];
@@ -388,7 +389,7 @@ export async function searchFilesFromIndex({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   let pageToken: string | undefined = undefined;
   const files: { name: string; fileId: string }[] = [];
@@ -436,7 +437,7 @@ export async function readFileFromIndex({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const response = await client.beta.retrieval.read({
     project_id: projectId,
@@ -467,7 +468,7 @@ export async function grepFileFromIndex({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const grepMatches: RetrievalGrepResponse[] = [];
   let pageToken: string | undefined = undefined;
@@ -511,7 +512,7 @@ export async function retrieveFromIndex({
 }) {
   const client = new LlamaCloud({
     apiKey: authToken,
-    baseURL: process.env.LLAMA_CLOUD_BASE_URL,
+    baseURL: llamaCloudBaseUrl(),
   });
   const response = await client.beta.retrieval.retrieve({
     project_id: projectId,

--- a/lib/region.ts
+++ b/lib/region.ts
@@ -18,13 +18,14 @@ const PROFILES: Record<Region, RegionProfile> = {
 
 const REGIONS = Object.keys(PROFILES) as Region[];
 
-function hostOf(url: string, varName: string): string {
-  try {
-    return new URL(url).host.toLowerCase();
-  } catch {
-    throw new Error(`${varName} is not a valid URL: "${url}"`);
-  }
+function hostOf(url: string): string {
+  return new URL(url).host.toLowerCase();
 }
+
+const API_HOSTS = REGIONS.map((region) => ({
+  region,
+  host: hostOf(PROFILES[region].apiBaseUrl),
+}));
 
 /**
  * The region this deployment serves. Defaults to `na` so an unset variable keeps
@@ -59,20 +60,33 @@ export function llamaCloudBaseUrl(): string {
     return regionProfile().apiBaseUrl;
   }
 
+  let overrideHost: string;
+  try {
+    overrideHost = hostOf(override);
+  } catch {
+    throw new Error(`LLAMA_CLOUD_BASE_URL is not a valid URL: "${override}"`);
+  }
+
   const region = getRegion();
-  const overrideHost = hostOf(override, 'LLAMA_CLOUD_BASE_URL');
-  for (const other of REGIONS) {
-    if (
-      other !== region &&
-      overrideHost ===
-        hostOf(PROFILES[other].apiBaseUrl, 'LLAMA_CLOUD_BASE_URL')
-    ) {
-      throw new Error(
-        `LLAMA_CLOUD_BASE_URL points at the ${PROFILES[other].label} API ("${override}") ` +
-          `but LLAMA_CLOUD_REGION is "${region}" (${PROFILES[region].label}).`
-      );
-    }
+  const foreign = API_HOSTS.find(
+    (entry) => entry.region !== region && entry.host === overrideHost
+  );
+  if (foreign) {
+    throw new Error(
+      `LLAMA_CLOUD_BASE_URL points at the ${PROFILES[foreign.region].label} API ("${override}") ` +
+        `but LLAMA_CLOUD_REGION is "${region}" (${PROFILES[region].label}).`
+    );
   }
 
   return override.replace(/\/+$/, '');
+}
+
+/**
+ * Fail a misconfigured deployment at boot rather than on every tool call.
+ * Called from `instrumentation.ts`, which Next runs once per runtime at startup:
+ * without it a bad region deploys green and only surfaces as a per-request error
+ * that reaches the MCP client, long after the deployment has gone live.
+ */
+export function assertRegionConfig(): void {
+  llamaCloudBaseUrl();
 }

--- a/lib/region.ts
+++ b/lib/region.ts
@@ -1,0 +1,78 @@
+export type Region = 'na' | 'eu';
+
+type RegionProfile = {
+  label: string;
+  apiBaseUrl: string;
+};
+
+const PROFILES: Record<Region, RegionProfile> = {
+  na: {
+    label: 'North America (NA)',
+    apiBaseUrl: 'https://api.cloud.llamaindex.ai',
+  },
+  eu: {
+    label: 'Europe (EU)',
+    apiBaseUrl: 'https://api.cloud.eu.llamaindex.ai',
+  },
+};
+
+const REGIONS = Object.keys(PROFILES) as Region[];
+
+function hostOf(url: string, varName: string): string {
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    throw new Error(`${varName} is not a valid URL: "${url}"`);
+  }
+}
+
+/**
+ * The region this deployment serves. Defaults to `na` so an unset variable keeps
+ * the historical single-region behaviour.
+ */
+export function getRegion(): Region {
+  const raw = process.env.LLAMA_CLOUD_REGION?.trim().toLowerCase();
+  if (!raw) {
+    return 'na';
+  }
+  if (!REGIONS.includes(raw as Region)) {
+    throw new Error(
+      `Invalid LLAMA_CLOUD_REGION "${process.env.LLAMA_CLOUD_REGION}" — expected one of: ${REGIONS.join(', ')}`
+    );
+  }
+  return raw as Region;
+}
+
+export function regionProfile(): RegionProfile {
+  return PROFILES[getRegion()];
+}
+
+/**
+ * LlamaCloud API base for this deployment. `LLAMA_CLOUD_BASE_URL` remains an
+ * override for local development and staging, but may never point at another
+ * region's API: documents transit this server, so a cross-region base URL would
+ * move them out of the region they were promised to stay in.
+ */
+export function llamaCloudBaseUrl(): string {
+  const override = process.env.LLAMA_CLOUD_BASE_URL?.trim();
+  if (!override) {
+    return regionProfile().apiBaseUrl;
+  }
+
+  const region = getRegion();
+  const overrideHost = hostOf(override, 'LLAMA_CLOUD_BASE_URL');
+  for (const other of REGIONS) {
+    if (
+      other !== region &&
+      overrideHost ===
+        hostOf(PROFILES[other].apiBaseUrl, 'LLAMA_CLOUD_BASE_URL')
+    ) {
+      throw new Error(
+        `LLAMA_CLOUD_BASE_URL points at the ${PROFILES[other].label} API ("${override}") ` +
+          `but LLAMA_CLOUD_REGION is "${region}" (${PROFILES[region].label}).`
+      );
+    }
+  }
+
+  return override.replace(/\/+$/, '');
+}


### PR DESCRIPTION
Part of LI-8474 — making `mcp.llamaindex.ai` work against the EU LlamaCloud instance.
**PR 1 of 7.** Region plumbing only; no EU endpoint is announced here, so this is safe to merge on its own.

## Why

The API base URL was a single deploy-wide env var (`LLAMA_CLOUD_BASE_URL`), read directly at 15 client-construction sites. That pins the server to one LlamaCloud region.

This is the first of three NA-neutral hardening PRs that make the codebase region-safe, ahead of standing up `mcp.eu.llamaindex.ai` as a second deployment.

## What

- **New `lib/region.ts`** — `LLAMA_CLOUD_REGION` (`na` default, or `eu`) is the single region switch, and the API base is derived from it.
- **`LLAMA_CLOUD_BASE_URL` is demoted to an override** for local development and staging, and is now *rejected* when it points at another region's API.
- **15 call sites** now go through `llamaCloudBaseUrl()` — 12 in `lib/business/llamaparse.ts`, 2 in `lib/business/liteparse.ts`, 1 in `app/api/upload/[token]/route.ts`. No raw reads of the variable remain outside `lib/region.ts`.
- **16 new tests** in `__tests__/region.test.ts` (suite: 23 passing).

### Why the override is guarded

Document bytes transit this server rather than going straight to LlamaCloud — `getUploadUrl` proxies the multipart body through `/api/upload/[token]`, `uploadFileByUrl` fetches server-side, and `parseFileWithLiteParse` downloads the file and runs WASM parsing in the function. A base URL pointing at the wrong region would move customer documents out of the region they were promised to stay in, so that combination fails loudly instead of being served.

## NA behaviour is unchanged

The previous code passed `undefined` to the SDK whenever the variable was unset. The SDK's own fallback is `https://api.cloud.llamaindex.ai` (`client.js:76` — `baseURL || 'https://api.cloud.llamaindex.ai'`), which is exactly what `na` now derives.

I also checked `#baseURLOverridden` (`client.js:152`, `:494`), which branches on exact string equality with the NA default and could have made a non-default base URL take a different path. No resource in the SDK declares a `defaultBaseURL`, so that branch is inert regardless.

## Note on naming

The design doc specified `NEXT_PUBLIC_REGION`, to match the LlamaCloud console's `runtimeFlags.region`. This uses `LLAMA_CLOUD_REGION` instead: every consumer here is server-side, and the `NEXT_PUBLIC_` prefix would inline a server config knob into the client bundle and make the module resist testing (Next substitutes the literal at build time). The `na` / `eu` value domain is unchanged.

## Testing

`pnpm test` 23/23 · `npx tsc --noEmit` clean · `pnpm lint` clean · `pnpm prettier` clean · `pnpm build` succeeds.

## Follow-ups in this series

| PR | Responsibility |
|---|---|
| 2 | OAuth discovery documents: `resource` as a URI, shared origin normalization |
| 3 | Issuer pinning + an error naming the sibling region |
| 4–7 | Announce the EU endpoint (README/SKILL.md, console, docs, agent plugins) — **gated** on the EU deployment being live |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY5WM9SdkDecVPXhLJYqZp