### PR TITLE
LI-8474: make the residency guard actually enforce residency

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ REDIS_URI=redis://localhost:6379
 
 > **WorkOS setup tip:** In your WorkOS dashboard, add `http://localhost:3000/callback` as an allowed redirect URI for local development.
 
+> **Deploying `LLAMA_CLOUD_REGION=eu`:** the function region must also be in the
+> EU. Documents are uploaded through this server, downloaded back for LiteParse,
+> and parsed in the function, so pointing at the EU API is not on its own enough
+> to keep them in region. Set the Vercel project's function region to `fra1`,
+> `cdg1`, `arn1` or `dub1` — Vercel's default for a new project is `iad1`. An EU
+> deployment left on the default still *deploys*; it then returns 500 for every
+> request until the function region is corrected. Set it in **project
+> settings**, not in a `vercel.json`: that file is shared with the NA project and
+> would relocate its traffic too.
+
 ### 3. Run the dev server
 
 ```bash

--- a/__tests__/region.test.ts
+++ b/__tests__/region.test.ts
@@ -3,6 +3,7 @@ import {
   getRegion,
   llamaCloudBaseUrl,
   regionProfile,
+  RegionConfigError,
 } from '../lib/region';
 
 const NA_API = 'https://api.cloud.llamaindex.ai';
@@ -15,25 +16,25 @@ describe('region', () => {
     process.env = { ...originalEnv };
     delete process.env.LLAMA_CLOUD_REGION;
     delete process.env.LLAMA_CLOUD_BASE_URL;
+    delete process.env.VERCEL_REGION;
+    delete process.env.NEXT_RUNTIME;
   });
 
   afterAll(() => {
     process.env = originalEnv;
   });
 
-  describe('getRegion', () => {
-    it('defaults to na when unset', () => {
+  describe('resolution without an override', () => {
+    it('defaults to na', () => {
       expect(getRegion()).toBe('na');
+      expect(llamaCloudBaseUrl()).toBe(NA_API);
     });
 
-    it('defaults to na when empty', () => {
-      process.env.LLAMA_CLOUD_REGION = '';
-      expect(getRegion()).toBe('na');
-    });
-
-    it('reads eu', () => {
+    it('honours a declared eu region', () => {
       process.env.LLAMA_CLOUD_REGION = 'eu';
       expect(getRegion()).toBe('eu');
+      expect(llamaCloudBaseUrl()).toBe(EU_API);
+      expect(regionProfile().label).toBe('Europe (EU)');
     });
 
     it('is case- and whitespace-insensitive', () => {
@@ -41,88 +42,271 @@ describe('region', () => {
       expect(getRegion()).toBe('eu');
     });
 
-    it('throws on an unknown region', () => {
+    it('rejects an unknown region', () => {
       process.env.LLAMA_CLOUD_REGION = 'apac';
       expect(() => getRegion()).toThrow(/Invalid LLAMA_CLOUD_REGION "apac"/);
     });
+
+    // Present-but-blank means someone intended to set it; treating that as
+    // unset would silently resolve an EU-intended deployment to NA.
+    // Silently ignoring a set-but-empty override would point a local deployment
+    // at the production API with the operator's live key.
+    it('rejects a present-but-blank base url', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = '  ';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /LLAMA_CLOUD_BASE_URL is set but empty/
+      );
+    });
+
+    it('rejects a present-but-blank region', () => {
+      process.env.LLAMA_CLOUD_REGION = '  ';
+      expect(() => getRegion()).toThrow(/is set but empty/);
+    });
   });
 
-  describe('regionProfile', () => {
-    it('describes na', () => {
-      expect(regionProfile()).toEqual({
-        label: 'North America (NA)',
-        apiBaseUrl: NA_API,
-      });
-    });
-
-    it('describes eu', () => {
-      process.env.LLAMA_CLOUD_REGION = 'eu';
-      expect(regionProfile()).toEqual({
-        label: 'Europe (EU)',
-        apiBaseUrl: EU_API,
-      });
-    });
-  });
-
-  describe('llamaCloudBaseUrl', () => {
-    it('derives the na api base by default', () => {
-      expect(llamaCloudBaseUrl()).toBe(NA_API);
-    });
-
-    it('derives the eu api base in the eu region', () => {
-      process.env.LLAMA_CLOUD_REGION = 'eu';
+  describe('region derived from the base url', () => {
+    // The pre-existing single-variable configuration: LLAMA_CLOUD_BASE_URL was
+    // the whole story, so it must keep working and must not be read as NA.
+    it('infers eu from the eu api host with no region declared', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
+      expect(getRegion()).toBe('eu');
       expect(llamaCloudBaseUrl()).toBe(EU_API);
     });
 
-    it('honours an override', () => {
+    it('infers na from the na api host with no region declared', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = NA_API;
+      expect(getRegion()).toBe('na');
+    });
+
+    it('accepts a declared region that agrees with the host', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
+      expect(getRegion()).toBe('eu');
+    });
+
+    it('rejects a declared region that disagrees with the host', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = NA_API;
+      expect(() => getRegion()).toThrow(
+        /LLAMA_CLOUD_REGION is "eu" .* but LLAMA_CLOUD_BASE_URL points at the North America \(NA\) API/
+      );
+    });
+
+    it('rejects the mismatch in the other direction too', () => {
+      process.env.LLAMA_CLOUD_REGION = 'na';
+      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
+      expect(() => getRegion()).toThrow(
+        /LLAMA_CLOUD_REGION is "na" .* points at the Europe \(EU\) API/
+      );
+    });
+  });
+
+  describe('override allowlist', () => {
+    // The SDK concatenates paths onto the base URL, so a path here would
+    // double-prefix every request.
+    it('rejects a region api carrying a path', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = `${EU_API}/api`;
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /must be an origin, with no path/
+      );
+    });
+
+    it('accepts a bare loopback host and port with a scheme', () => {
+      process.env.LLAMA_CLOUD_REGION = 'na';
       process.env.LLAMA_CLOUD_BASE_URL = 'http://localhost:8000';
       expect(llamaCloudBaseUrl()).toBe('http://localhost:8000');
     });
 
-    it('ignores a blank override', () => {
+    it('rejects an unrecognised host outright', () => {
       process.env.LLAMA_CLOUD_REGION = 'eu';
-      process.env.LLAMA_CLOUD_BASE_URL = '   ';
-      expect(llamaCloudBaseUrl()).toBe(EU_API);
+      process.env.LLAMA_CLOUD_BASE_URL = 'https://api.staging.llamaindex.ai';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /host "api.staging.llamaindex.ai" is not a recognised LlamaCloud API/
+      );
     });
 
-    it('strips trailing slashes from an override', () => {
-      process.env.LLAMA_CLOUD_BASE_URL = 'http://localhost:8000//';
+    it('rejects an arbitrary third-party host', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'https://evil.example.com';
+      expect(() => llamaCloudBaseUrl()).toThrow(/is not a recognised/);
+    });
+
+    it('allows a loopback host when the region is declared', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'http://localhost:8000';
+      expect(getRegion()).toBe('eu');
       expect(llamaCloudBaseUrl()).toBe('http://localhost:8000');
     });
 
-    it('allows an override matching the configured region', () => {
-      process.env.LLAMA_CLOUD_REGION = 'eu';
-      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
-      expect(llamaCloudBaseUrl()).toBe(EU_API);
-    });
-
-    it('rejects an eu deployment pointed at the na api', () => {
-      process.env.LLAMA_CLOUD_REGION = 'eu';
-      process.env.LLAMA_CLOUD_BASE_URL = NA_API;
-      expect(() => llamaCloudBaseUrl()).toThrow(
-        /points at the North America \(NA\) API .* but LLAMA_CLOUD_REGION is "eu"/
-      );
-    });
-
-    it('rejects an na deployment pointed at the eu api', () => {
+    it('allows ipv6 loopback', () => {
       process.env.LLAMA_CLOUD_REGION = 'na';
-      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
-      expect(() => llamaCloudBaseUrl()).toThrow(
-        /points at the Europe \(EU\) API .* but LLAMA_CLOUD_REGION is "na"/
-      );
+      process.env.LLAMA_CLOUD_BASE_URL = 'http://[::1]:8000';
+      expect(llamaCloudBaseUrl()).toBe('http://[::1]:8000');
     });
 
-    it('rejects a cross-region override regardless of trailing path or case', () => {
+    it('requires an explicit scheme for a loopback override', () => {
+      // Bare `127.0.0.1:8000` normalises to https; a local API is rarely TLS,
+      // so that boots green and then fails every request on a handshake.
       process.env.LLAMA_CLOUD_REGION = 'eu';
-      process.env.LLAMA_CLOUD_BASE_URL = 'https://API.Cloud.LlamaIndex.ai/';
-      expect(() => llamaCloudBaseUrl()).toThrow(/North America \(NA\)/);
+      process.env.LLAMA_CLOUD_BASE_URL = '127.0.0.1:8000';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /must include an explicit http:\/\/ or https:\/\/ scheme/
+      );
     });
 
-    it('throws on a malformed override', () => {
-      process.env.LLAMA_CLOUD_BASE_URL = 'not-a-url';
+    it('rejects a base url embedding credentials', () => {
+      // fetch() refuses a URL with credentials and puts them in its message,
+      // which is rethrown to the caller.
+      process.env.LLAMA_CLOUD_BASE_URL = `https://svc:s3cr3t@api.cloud.eu.llamaindex.ai`;
+      expect(() => llamaCloudBaseUrl()).toThrow(/must not embed credentials/);
+      expect(() => llamaCloudBaseUrl()).not.toThrow(/s3cr3t/);
+    });
+
+    it('requires a declared region for a loopback override', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = 'http://localhost:8000';
       expect(() => llamaCloudBaseUrl()).toThrow(
-        /LLAMA_CLOUD_BASE_URL is not a valid URL/
+        /LLAMA_CLOUD_REGION must state the region this deployment serves/
       );
+    });
+
+    // A scheme-less value gains https, so this resolves to the NA API and is
+    // caught as a region conflict rather than as an unrecognised host.
+    it('gives a scheme-less foreign host the same treatment as an absolute one', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'api.cloud.llamaindex.ai';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /but LLAMA_CLOUD_BASE_URL points at the North America \(NA\) API/
+      );
+    });
+
+    it('rejects a non-http scheme', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'file:///etc/passwd';
+      expect(() => llamaCloudBaseUrl()).toThrow(/must use http or https/);
+    });
+
+    it('rejects a query string on the override', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = `${EU_API}/?tenant=acme`;
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /must not carry a query or fragment/
+      );
+    });
+  });
+
+  describe('dns-equivalent spellings of a foreign host', () => {
+    it('rejects a trailing-dot fqdn of the other region', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'https://api.cloud.llamaindex.ai./';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /points at the North America \(NA\) API/
+      );
+    });
+
+    it('rejects the other region on an explicit port', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'https://api.cloud.llamaindex.ai:8443';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /points at the North America \(NA\) API/
+      );
+    });
+
+    it('rejects a mixed-case spelling of the other region', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'https://API.Cloud.LlamaIndex.ai';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /points at the North America \(NA\) API/
+      );
+    });
+  });
+
+  describe('transport security', () => {
+    it('rejects cleartext http to a region api', () => {
+      process.env.LLAMA_CLOUD_BASE_URL = 'http://api.cloud.eu.llamaindex.ai';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /must use https .* would send the API key and document contents in cleartext/
+      );
+    });
+
+    it('still allows cleartext http to loopback', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'http://localhost:8000';
+      expect(() => llamaCloudBaseUrl()).not.toThrow();
+    });
+  });
+
+  // Callers branch on this type to avoid advising a retry that can never
+  // succeed. Every configuration failure must carry it, including the ones
+  // delegated to normalizeBaseUrl, which throws plain Errors that are wrapped.
+  describe('error type', () => {
+    it.each([
+      ['unknown region', { LLAMA_CLOUD_REGION: 'apac' }],
+      [
+        'cross-region base url',
+        { LLAMA_CLOUD_REGION: 'eu', LLAMA_CLOUD_BASE_URL: NA_API },
+      ],
+      [
+        'unrecognised host',
+        {
+          LLAMA_CLOUD_REGION: 'eu',
+          LLAMA_CLOUD_BASE_URL: 'https://api.staging.llamaindex.ai',
+        },
+      ],
+      [
+        'cleartext transport',
+        { LLAMA_CLOUD_BASE_URL: 'http://api.cloud.eu.llamaindex.ai' },
+      ],
+      [
+        'embedded credentials',
+        { LLAMA_CLOUD_BASE_URL: 'https://u:p@api.cloud.eu.llamaindex.ai' },
+      ],
+      [
+        'delegated: non-http scheme',
+        { LLAMA_CLOUD_REGION: 'eu', LLAMA_CLOUD_BASE_URL: 'ftp://example.com' },
+      ],
+      [
+        'delegated: query component',
+        { LLAMA_CLOUD_REGION: 'eu', LLAMA_CLOUD_BASE_URL: `${EU_API}/?a=1` },
+      ],
+    ])('reports %s as a RegionConfigError', (_name, env) => {
+      Object.assign(process.env, env);
+      expect(() => llamaCloudBaseUrl()).toThrow(RegionConfigError);
+    });
+  });
+
+  describe('error messages', () => {
+    // These throws are rethrown to remote MCP clients (lib/mcp/tools/tools.ts),
+    // so no rejection path may echo an override's credentials. Each case below
+    // exits through a different throw site.
+    it('rejects credentials outright rather than quoting them', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL =
+        'https://svc:s3cr3t@internal-proxy.corp.internal:8443/';
+      expect(() => llamaCloudBaseUrl()).toThrow(/must not embed credentials/);
+      expect(() => llamaCloudBaseUrl()).not.toThrow(/s3cr3t/);
+    });
+
+    it('names the host, not the value, for an unrecognised override', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL =
+        'https://internal-proxy.corp.internal:8443/';
+      expect(() => llamaCloudBaseUrl()).toThrow(/internal-proxy.corp.internal/);
+    });
+
+    it('redacts credentials when the override carries a query', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL =
+        'https://svc:s3cr3t@proxy.corp.internal/?tenant=acme';
+      expect(() => llamaCloudBaseUrl()).toThrow(
+        /must not carry a query or fragment/
+      );
+      expect(() => llamaCloudBaseUrl()).not.toThrow(/s3cr3t/);
+    });
+
+    it('redacts credentials when the override does not parse', () => {
+      process.env.LLAMA_CLOUD_REGION = 'eu';
+      process.env.LLAMA_CLOUD_BASE_URL = 'https://svc:s3cr3t@';
+      expect(() => llamaCloudBaseUrl()).toThrow(/is not a valid URL/);
+      expect(() => llamaCloudBaseUrl()).not.toThrow(/s3cr3t/);
     });
   });
 
@@ -131,10 +315,74 @@ describe('region', () => {
       expect(() => assertRegionConfig()).not.toThrow();
     });
 
-    it('accepts a consistent eu configuration', () => {
+    it('rejects a cross-region base url', () => {
       process.env.LLAMA_CLOUD_REGION = 'eu';
-      process.env.LLAMA_CLOUD_BASE_URL = EU_API;
-      expect(() => assertRegionConfig()).not.toThrow();
+      process.env.LLAMA_CLOUD_BASE_URL = NA_API;
+      expect(() => assertRegionConfig()).toThrow(/North America \(NA\)/);
+    });
+
+    describe('compute region', () => {
+      // Node runtime only: Vercel ships middleware to every PoP, where
+      // VERCEL_REGION is the serving PoP rather than the function's region.
+      beforeEach(() => {
+        process.env.NEXT_RUNTIME = 'nodejs';
+      });
+
+      it('accepts an eu deployment running in an eu vercel region', () => {
+        process.env.LLAMA_CLOUD_REGION = 'eu';
+        process.env.VERCEL_REGION = 'fra1';
+        expect(() => assertRegionConfig()).not.toThrow();
+      });
+
+      it('rejects an eu deployment running in a us vercel region', () => {
+        process.env.LLAMA_CLOUD_REGION = 'eu';
+        process.env.VERCEL_REGION = 'iad1';
+        expect(() => assertRegionConfig()).toThrow(
+          /functions run in Vercel region "iad1"/
+        );
+      });
+
+      it('rejects lhr1, which is not in the eu', () => {
+        process.env.LLAMA_CLOUD_REGION = 'eu';
+        process.env.VERCEL_REGION = 'lhr1';
+        expect(() => assertRegionConfig()).toThrow(/"lhr1"/);
+      });
+
+      // The region can come from the base URL alone, and the residency check
+      // must still apply to it.
+      it('applies to a region derived from the base url', () => {
+        process.env.LLAMA_CLOUD_BASE_URL = EU_API;
+        process.env.VERCEL_REGION = 'iad1';
+        expect(() => assertRegionConfig()).toThrow(
+          /serves Europe \(EU\) but its functions run in Vercel region "iad1"/
+        );
+      });
+
+      // Asserting in the edge runtime would 500 an EU deployment in every
+      // non-EU PoP, because middleware is deployed everywhere.
+      it('does not run in the edge runtime', () => {
+        process.env.NEXT_RUNTIME = 'edge';
+        process.env.LLAMA_CLOUD_REGION = 'eu';
+        process.env.VERCEL_REGION = 'iad1';
+        expect(() => assertRegionConfig()).not.toThrow();
+      });
+
+      it('skips the check during a build', () => {
+        process.env.LLAMA_CLOUD_REGION = 'eu';
+        process.env.VERCEL_REGION = 'dev1';
+        expect(() => assertRegionConfig()).not.toThrow();
+      });
+
+      it('skips the check off Vercel', () => {
+        process.env.LLAMA_CLOUD_REGION = 'eu';
+        expect(() => assertRegionConfig()).not.toThrow();
+      });
+
+      it('does not constrain na compute', () => {
+        process.env.LLAMA_CLOUD_REGION = 'na';
+        process.env.VERCEL_REGION = 'fra1';
+        expect(() => assertRegionConfig()).not.toThrow();
+      });
     });
 
     it('rejects an unknown region', () => {
@@ -142,17 +390,10 @@ describe('region', () => {
       expect(() => assertRegionConfig()).toThrow(/Invalid LLAMA_CLOUD_REGION/);
     });
 
-    it('rejects a cross-region base url override', () => {
+    it('rejects a malformed base url', () => {
       process.env.LLAMA_CLOUD_REGION = 'eu';
-      process.env.LLAMA_CLOUD_BASE_URL = NA_API;
-      expect(() => assertRegionConfig()).toThrow(/North America \(NA\)/);
-    });
-
-    it('rejects a malformed base url override', () => {
-      process.env.LLAMA_CLOUD_BASE_URL = 'not-a-url';
-      expect(() => assertRegionConfig()).toThrow(
-        /LLAMA_CLOUD_BASE_URL is not a valid URL/
-      );
+      process.env.LLAMA_CLOUD_BASE_URL = 'ftp://example.com';
+      expect(() => assertRegionConfig()).toThrow(/must use http or https/);
     });
   });
 });

--- a/app/api/upload/[token]/route.ts
+++ b/app/api/upload/[token]/route.ts
@@ -1,7 +1,7 @@
 import { getKVStore } from '@/lib/business/kv';
 import { NextRequest, NextResponse } from 'next/server';
 import LlamaCloud from '@llamaindex/llama-cloud';
-import { llamaCloudBaseUrl } from '@/lib/region';
+import { llamaCloudBaseUrl, RegionConfigError } from '@/lib/region';
 import { getLogger } from '@/lib/observability/logger';
 
 // @ts-expect-error params is implictly any
@@ -64,6 +64,16 @@ export async function POST(req: NextRequest, { params }) {
     }
     return NextResponse.json({ file_id: fileObj.id }, { status: 200 });
   } catch (e) {
+    // Defensive: a configuration error normally aborts boot in
+    // instrumentation.ts, so this rarely fires. When it does it is permanent,
+    // so it gets neither the retry advice nor a generic-failure framing.
+    if (e instanceof RegionConfigError) {
+      getLogger().error(`Upload blocked by a server configuration error: ${e}`);
+      return NextResponse.json(
+        { detail: 'The server is misconfigured. Contact the administrator.' },
+        { status: 500 }
+      );
+    }
     // Never interpolate the error: this endpoint is reachable before the token
     // is validated, and the browser form renders the response body verbatim, so
     // a Redis or config failure would put internal detail in front of any

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -5,7 +5,13 @@ import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
   {
-    ignores: ['.next/**', 'node_modules/**', 'jest.*.js', 'next.*.ts'],
+    ignores: [
+      '.next/**',
+      'node_modules/**',
+      'coverage/**',
+      'jest.*.js',
+      'next.*.ts',
+    ],
   },
   {
     files: [
@@ -20,4 +26,79 @@ export default defineConfig([
     languageOptions: { globals: { ...globals.browser, ...globals.node } },
   },
   tseslint.configs.recommended,
+  {
+    // The SDK falls back to reading LLAMA_CLOUD_BASE_URL itself, and then to the
+    // NA API, so a client constructed without an explicit baseURL silently
+    // bypasses the region guard and ships EU documents to North America.
+    //
+    // Three rules, none of them airtight on its own: the env reads stay in one
+    // place; a construction spelled `new LlamaCloud` must pass a baseURL; and
+    // the SDK cannot be imported outside the modules that already construct
+    // clients, so a new call site is a lint error rather than a silent bypass.
+    // A renamed import inside those modules, `baseURL: undefined`, or a key
+    // computed at runtime all still slip through — this raises the cost of an
+    // accidental reversion, it is not a boundary. The structural fix is a single
+    // factory that owns construction; see the follow-up note in the PR.
+    files: [
+      'lib/**/*.ts',
+      'lib/**/*.tsx',
+      'app/**/*.ts',
+      'app/**/*.tsx',
+      'instrumentation.ts',
+      'middleware.ts',
+    ],
+    ignores: ['lib/region.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          // patterns, not paths: the repo already imports subpaths of this
+          // package, so an exact-specifier rule would miss the spelling a
+          // developer most plausibly reaches for.
+          patterns: [
+            {
+              group: ['@llamaindex/llama-cloud', '@llamaindex/llama-cloud/*'],
+              message:
+                'Construct LlamaCloud only where the region guard is applied (lib/business/*, app/api/upload). A new call site must pass baseURL: llamaCloudBaseUrl().',
+            },
+          ],
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'MemberExpression[object.object.name="process"][object.property.name="env"][property.name=/^LLAMA_CLOUD_(BASE_URL|REGION)$/]',
+          message:
+            'Read this through lib/region.ts (llamaCloudBaseUrl / getRegion) so the region guard cannot be bypassed.',
+        },
+        {
+          selector:
+            'MemberExpression[object.object.name="process"][object.property.name="env"][property.value=/^LLAMA_CLOUD_(BASE_URL|REGION)$/]',
+          message:
+            'Read this through lib/region.ts (llamaCloudBaseUrl / getRegion) so the region guard cannot be bypassed.',
+        },
+        {
+          selector:
+            'VariableDeclarator[init.object.name="process"][init.property.name="env"] > ObjectPattern > Property[key.name=/^LLAMA_CLOUD_(BASE_URL|REGION)$/]',
+          message:
+            'Read this through lib/region.ts (llamaCloudBaseUrl / getRegion) so the region guard cannot be bypassed.',
+        },
+        {
+          // The bypass the env rules cannot see: omitting baseURL entirely makes
+          // the SDK read the raw variable itself and then fall back to the NA
+          // API, so an EU deployment would ship documents to North America.
+          selector:
+            'NewExpression[callee.name="LlamaCloud"]:not(:has(ObjectExpression > Property[key.name="baseURL"]))',
+          message:
+            'Construct LlamaCloud with `baseURL: llamaCloudBaseUrl()`. Without it the SDK falls back to the NA API and the region guard is bypassed.',
+        },
+      ],
+    },
+  },
+  {
+    // The modules that already construct clients, all of which pass baseURL.
+    files: ['lib/business/*.ts', 'app/api/upload/**/*.ts'],
+    rules: { 'no-restricted-imports': 'off' },
+  },
 ]);

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,7 +2,8 @@ import { registerOTel, OTLPHttpJsonTraceExporter } from '@vercel/otel';
 import { assertRegionConfig } from './lib/region';
 
 export function register() {
-  assertRegionConfig();
+  // OTel first: a region misconfiguration is exactly the failure that makes the
+  // service dark, and Next never retries this hook once it throws.
   registerOTel({
     serviceName: 'llamaindex-mcp-traces',
     traceExporter: new OTLPHttpJsonTraceExporter({
@@ -13,4 +14,5 @@ export function register() {
       },
     }),
   });
+  assertRegionConfig();
 }

--- a/lib/region.ts
+++ b/lib/region.ts
@@ -1,92 +1,219 @@
+import 'server-only';
+import { isLoopbackHostname, normalizeBaseUrl } from './urls';
+
 export type Region = 'na' | 'eu';
 
+/**
+ * A deployment misconfiguration, as distinct from a runtime failure. Callers
+ * use this to avoid telling a user to retry something that can never succeed,
+ * and to avoid echoing a message that names internal hosts.
+ */
+export class RegionConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RegionConfigError';
+  }
+}
+
 type RegionProfile = {
-  label: string;
-  apiBaseUrl: string;
+  readonly label: string;
+  readonly apiBaseUrl: string;
+  /**
+   * Vercel regions whose compute satisfies this region's residency commitment.
+   * Documents are terminated and parsed inside the function, so the API host
+   * alone does not keep them in region.
+   *
+   * Only `eu` is constrained: it is the region with a published commitment
+   * ("all data provided will remain within the EU region for storage and
+   * processing"). Deliberately excludes lhr1 and zrh1 — the UK and Switzerland
+   * hold adequacy decisions but are not in the EU. `na` is left unconstrained
+   * because there is no equivalent commitment and the existing deployment does
+   * not pin a function region.
+   */
+  readonly computeRegions?: readonly string[];
 };
 
-const PROFILES: Record<Region, RegionProfile> = {
-  na: {
+const PROFILES: Record<Region, RegionProfile> = Object.freeze({
+  na: Object.freeze({
     label: 'North America (NA)',
     apiBaseUrl: 'https://api.cloud.llamaindex.ai',
-  },
-  eu: {
+  }),
+  eu: Object.freeze({
     label: 'Europe (EU)',
     apiBaseUrl: 'https://api.cloud.eu.llamaindex.ai',
-  },
-};
+    computeRegions: Object.freeze(['fra1', 'cdg1', 'arn1', 'dub1']),
+  }),
+});
 
 const REGIONS = Object.keys(PROFILES) as Region[];
 
-function hostOf(url: string): string {
-  return new URL(url).host.toLowerCase();
+/** Vercel reports this during a build; it is not the region traffic is served from. */
+const BUILD_TIME_VERCEL_REGION = 'dev1';
+
+function hostnameOf(url: URL): string {
+  return url.hostname.toLowerCase().replace(/\.$/, '');
 }
 
-const API_HOSTS = REGIONS.map((region) => ({
+const API_HOSTNAMES = REGIONS.map((region) => ({
   region,
-  host: hostOf(PROFILES[region].apiBaseUrl),
+  hostname: hostnameOf(new URL(PROFILES[region].apiBaseUrl)),
 }));
 
-/**
- * The region this deployment serves. Defaults to `na` so an unset variable keeps
- * the historical single-region behaviour.
- */
-export function getRegion(): Region {
-  const raw = process.env.LLAMA_CLOUD_REGION?.trim().toLowerCase();
+function declaredRegion(): Region | undefined {
+  const declared = process.env.LLAMA_CLOUD_REGION;
+  if (declared === undefined) {
+    return undefined;
+  }
+  // A present-but-blank value means someone intended to set this; treating it
+  // as unset would silently resolve to NA.
+  const raw = declared.trim().toLowerCase();
   if (!raw) {
-    return 'na';
+    throw new RegionConfigError(
+      `LLAMA_CLOUD_REGION is set but empty — remove it, or set one of: ${REGIONS.join(', ')}`
+    );
   }
   if (!REGIONS.includes(raw as Region)) {
-    throw new Error(
-      `Invalid LLAMA_CLOUD_REGION "${process.env.LLAMA_CLOUD_REGION}" — expected one of: ${REGIONS.join(', ')}`
+    // Quote the normalised value, not the raw one: this message reaches remote
+    // MCP clients, and it should name exactly what was tested.
+    throw new RegionConfigError(
+      `Invalid LLAMA_CLOUD_REGION "${raw}" — expected one of: ${REGIONS.join(', ')}`
     );
   }
   return raw as Region;
+}
+
+/**
+ * Resolve the region and API base URL together, so the two can never disagree.
+ *
+ * `LLAMA_CLOUD_BASE_URL` is an override for local development. When it names a
+ * known region's API it *determines* the region, which keeps the pre-existing
+ * single-variable configuration working and unambiguous. Any other host must be
+ * loopback and must state its region explicitly — an unrecognised host is
+ * refused rather than assumed to be in region, because documents transit this
+ * server and a wrong guess moves them out of the region they were promised to
+ * stay in.
+ *
+ * Error messages name only the hostname: the raw value can carry credentials
+ * and these throws reach remote MCP clients.
+ */
+function resolveRegionConfig(): { region: Region; baseUrl: string } {
+  const declared = declaredRegion();
+  const override = process.env.LLAMA_CLOUD_BASE_URL;
+  // Same reasoning as the blank region above: silently ignoring a set-but-empty
+  // override would point a local deployment at the production API.
+  if (override !== undefined && !override.trim()) {
+    throw new RegionConfigError(
+      'LLAMA_CLOUD_BASE_URL is set but empty — remove it, or give it a value'
+    );
+  }
+  const rawOverride = override?.trim();
+
+  if (!rawOverride) {
+    const region = declared ?? 'na';
+    return { region, baseUrl: PROFILES[region].apiBaseUrl };
+  }
+
+  let baseUrl: string;
+  try {
+    // originOnly: the SDK builds request URLs by concatenating onto this, so a
+    // path would double-prefix every call.
+    baseUrl = normalizeBaseUrl(rawOverride, 'LLAMA_CLOUD_BASE_URL', {
+      originOnly: true,
+    });
+  } catch (e) {
+    throw new RegionConfigError((e as Error).message);
+  }
+  const url = new URL(baseUrl);
+  const hostname = hostnameOf(url);
+
+  const match = API_HOSTNAMES.find((entry) => entry.hostname === hostname);
+  if (match) {
+    if (declared && declared !== match.region) {
+      throw new RegionConfigError(
+        `LLAMA_CLOUD_REGION is "${declared}" (${PROFILES[declared].label}) but LLAMA_CLOUD_BASE_URL points at the ${PROFILES[match.region].label} API ("${hostname}").`
+      );
+    }
+    if (url.protocol !== 'https:') {
+      throw new RegionConfigError(
+        `LLAMA_CLOUD_BASE_URL must use https for "${hostname}" — "${url.protocol}" would send the API key and document contents in cleartext.`
+      );
+    }
+    return { region: match.region, baseUrl };
+  }
+
+  if (isLoopbackHostname(hostname)) {
+    if (!declared) {
+      throw new RegionConfigError(
+        `LLAMA_CLOUD_BASE_URL points at "${hostname}", which is not a known region API, so LLAMA_CLOUD_REGION must state the region this deployment serves.`
+      );
+    }
+    // A bare `127.0.0.1:8000` is normalised to https, and a local API is almost
+    // never TLS — that combination boots green and then fails every request on
+    // a handshake error. Make the operator state the scheme.
+    if (!/^https?:\/\//i.test(rawOverride)) {
+      throw new RegionConfigError(
+        `LLAMA_CLOUD_BASE_URL must include an explicit http:// or https:// scheme for the local host "${hostname}".`
+      );
+    }
+    return { region: declared, baseUrl };
+  }
+
+  throw new RegionConfigError(
+    `LLAMA_CLOUD_BASE_URL host "${hostname}" is not a recognised LlamaCloud API. Allowed: ${API_HOSTNAMES.map((e) => e.hostname).join(', ')}, or a loopback host for local development.`
+  );
+}
+
+export function getRegion(): Region {
+  return resolveRegionConfig().region;
 }
 
 export function regionProfile(): RegionProfile {
   return PROFILES[getRegion()];
 }
 
-/**
- * LlamaCloud API base for this deployment. `LLAMA_CLOUD_BASE_URL` remains an
- * override for local development and staging, but may never point at another
- * region's API: documents transit this server, so a cross-region base URL would
- * move them out of the region they were promised to stay in.
- */
 export function llamaCloudBaseUrl(): string {
-  const override = process.env.LLAMA_CLOUD_BASE_URL?.trim();
-  if (!override) {
-    return regionProfile().apiBaseUrl;
-  }
-
-  let overrideHost: string;
-  try {
-    overrideHost = hostOf(override);
-  } catch {
-    throw new Error(`LLAMA_CLOUD_BASE_URL is not a valid URL: "${override}"`);
-  }
-
-  const region = getRegion();
-  const foreign = API_HOSTS.find(
-    (entry) => entry.region !== region && entry.host === overrideHost
-  );
-  if (foreign) {
-    throw new Error(
-      `LLAMA_CLOUD_BASE_URL points at the ${PROFILES[foreign.region].label} API ("${override}") ` +
-        `but LLAMA_CLOUD_REGION is "${region}" (${PROFILES[region].label}).`
-    );
-  }
-
-  return override.replace(/\/+$/, '');
+  return resolveRegionConfig().baseUrl;
 }
 
 /**
  * Fail a misconfigured deployment at boot rather than on every tool call.
- * Called from `instrumentation.ts`, which Next runs once per runtime at startup:
- * without it a bad region deploys green and only surfaces as a per-request error
- * that reaches the MCP client, long after the deployment has gone live.
+ * Called from `instrumentation.ts`, which Next runs once per runtime at startup.
  */
 export function assertRegionConfig(): void {
-  llamaCloudBaseUrl();
+  const { region } = resolveRegionConfig();
+  assertComputeRegion(region);
+}
+
+/**
+ * The API host says where requests go; it says nothing about where this server
+ * runs. Documents are proxied, downloaded and (for LiteParse) parsed inside the
+ * function, so a region with a residency commitment must also pin its compute.
+ *
+ * Node runtime only. Vercel deploys middleware to every PoP regardless of the
+ * project's region setting, so in the edge runtime `VERCEL_REGION` is whichever
+ * PoP served the request — asserting there would take an EU deployment offline
+ * everywhere outside the four EU cities. The functions that touch documents all
+ * run on Node.
+ *
+ * Skipped when `VERCEL_REGION` is absent (local development, CI, self-hosted)
+ * or reports the build-time placeholder, since neither is the region that
+ * serves traffic.
+ */
+function assertComputeRegion(region: Region): void {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') {
+    return;
+  }
+  const allowed = PROFILES[region].computeRegions;
+  if (!allowed) {
+    return;
+  }
+  const vercelRegion = process.env.VERCEL_REGION?.trim().toLowerCase();
+  if (!vercelRegion || vercelRegion === BUILD_TIME_VERCEL_REGION) {
+    return;
+  }
+  if (!allowed.includes(vercelRegion)) {
+    throw new RegionConfigError(
+      `This deployment serves ${PROFILES[region].label} but its functions run in Vercel region "${vercelRegion}". Documents are processed inside the function, so the compute region must be one of: ${allowed.join(', ')}.`
+    );
+  }
 }


### PR DESCRIPTION
Part of LI-8474. **Stacked on #19 — merge that first.** Base is #19's branch, so this diff stays scoped; CI runs on it once #19 merges and GitHub retargets it to `main`.

> Squashed and re-scoped after review. This description reflects the current code. The URL-validation and OAuth-discovery work that used to live here moved to #19, where those files live.

## Why

The residency guard #18 shipped did not deliver what its own docstring claimed. It checked residency with a **denylist of two literal hostnames**, so anything nobody thought to deny was accepted as in-region.

| config on an `eu` deployment | #18 | now |
|---|---|---|
| `https://api.staging.llamaindex.ai` | boots, sends EU docs to a US host | rejected at boot |
| `https://api.cloud.llamaindex.ai./` (trailing-dot FQDN, resolves identically) | boots, sends EU docs to NA | rejected |
| `https://api.cloud.llamaindex.ai:8443` | boots, sends EU docs to NA | rejected |
| `http://api.cloud.eu.llamaindex.ai` | boots, API key + document bytes in cleartext | rejected |
| `LLAMA_CLOUD_REGION` unset | silently `na` | derived from the base URL |
| `LLAMA_CLOUD_REGION=""` (set but blank) | silently `na` | rejected |
| functions running in `iad1` | boots, reports region-correct | rejected |

## What

**Allowlist, not denylist.** The override must be the configured region's own API, or a loopback host with an explicit scheme. https required off loopback, hostname compared normalised, no path (the SDK concatenates onto the base, so `.../api` would double-prefix every request).

**Region derived from the base URL** when that names a known region API. This also repairs a regression #18 introduced: a project carrying only `LLAMA_CLOUD_BASE_URL` — what existing deployments have, and what cloning the NA project's env produces — failed **the whole app** at boot, including `/.well-known/*` and `/upload`, none of which touch LlamaCloud.

**Compute region pinned.** The API host says where requests go; it says nothing about where this server runs, and documents are proxied, downloaded and LiteParse-parsed *inside the function*. An `eu` deployment asserts `VERCEL_REGION` is one of `fra1`/`cdg1`/`arn1`/`dub1` — deliberately **not** `lhr1` or `zrh1`, which hold adequacy decisions but are not in the EU.

### The assert must not run in edge middleware

Next runs instrumentation in every runtime and `middleware.ts` pulls it in, so the compute assert was compiled into the **Edge Middleware** bundle — confirmed in `.next/server/middleware-manifest.json`, which lists `edge-instrumentation.js` among the middleware's files. Vercel deploys middleware to **every PoP**, where `VERCEL_REGION` is the serving PoP. An EU deployment would have returned 500 for every request outside four European cities, on a matcher covering all app routes.

Gating on `NEXT_RUNTIME === 'nodejs'` fixes it, and the early return lets the bundler drop the path entirely — the guard's error string no longer appears in the edge bundle at all. The functions that touch documents are all Node, so the check still runs where residency is actually decided.

### Also

- Configuration failures carry a **`RegionConfigError`**, so callers can distinguish a permanent misconfiguration from a transient one instead of advising a retry that can never succeed.
- **OTel registers before the assert.** Previously the one failure the gate exists to catch was the one failure that emitted no telemetry — Next never retries `register()` once it throws, so a bad region meant a totally dark service.
- **An eslint guard** keeps the LlamaCloud env reads in one module, refuses a `LlamaCloud` construction with no `baseURL`, and refuses an SDK import outside the modules that already apply the guard. Its comment states plainly what still slips through (a renamed import, `baseURL: undefined`, a runtime-computed key) rather than implying it is a boundary; the structural fix is a single factory owning construction, noted as a follow-up.
- **README** documents the EU function-region requirement, which was otherwise a hard boot precondition with nothing in the repo pointing at it, and that arbitrary hosts including staging APIs are refused.

## Verification

Every row above was booted against a real production build, not just unit-tested:

```
MUST BOOT   na default · eu via region var · eu via base-url only (legacy 1-var)
            eu + fra1 · loopback w/ explicit scheme                        ✓
MUST REFUSE eu + NA api · staging host · cleartext http · embedded creds
            loopback w/o scheme · trailing-dot FQDN · bare '#' · bad region ✓
```

`pnpm test` **99 tests** · `tsc --noEmit` clean · `eslint` clean · `prettier` clean · `next build` succeeds. The eslint rules were each proved to fire against probe files rather than assumed.

## Deploy requirement

An EU Vercel project must have its function region set to `fra1`/`cdg1`/`arn1`/`dub1` in **project settings** — not in a `vercel.json`, which is shared with the NA project and would relocate its traffic. Vercel's default for a new project is `iad1`, and an EU deployment left on the default refuses to boot by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY5WM9SdkDecVPXhLJYqZp