### PR TITLE
LI-8474: tell a wrong-region client which endpoint to use

### DIFF
--- a/__tests__/token-errors.test.ts
+++ b/__tests__/token-errors.test.ts
@@ -1,0 +1,222 @@
+const ORIGINAL_ENV = process.env;
+
+async function load() {
+  return import('../lib/auth/token-errors');
+}
+
+/** Structurally valid, junk signature — all a wrong-region token is here. */
+function tokenIssuedBy(issuer: unknown): string {
+  const part = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString('base64url');
+  return [
+    part({ alg: 'RS256', kid: 'sso_oidc_key_pair_other_region' }),
+    part(issuer === undefined ? { sub: 'u' } : { sub: 'u', iss: issuer }),
+    'not-a-real-signature',
+  ].join('.');
+}
+
+const NA_TOKEN = tokenIssuedBy('https://login.llamaindex.ai');
+const EU_TOKEN = tokenIssuedBy('https://login.eu.llamaindex.ai');
+
+const UNVERIFIABLE = 'Invalid token signature. Please sign in again.';
+const GENERIC = 'Authentication failed. Please sign in again.';
+const EXPIRED = 'Your session has expired. Please sign in again.';
+
+const NA_HINT =
+  'This token was issued for the North America (NA) region, but this server serves Europe (EU). ' +
+  'If your LlamaCloud account is at https://cloud.llamaindex.ai, connect to https://mcp.llamaindex.ai/mcp instead.';
+const EU_HINT =
+  'This token was issued for the Europe (EU) region, but this server serves North America (NA). ' +
+  'If your LlamaCloud account is at https://cloud.eu.llamaindex.ai, connect to https://mcp.eu.llamaindex.ai/mcp instead.';
+
+const KEY_ERR = { code: 'ERR_JWKS_NO_MATCHING_KEY' };
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.LLAMA_CLOUD_BASE_URL;
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('authErrorMessage', () => {
+  // Asserted whole, not by substring: both labels appear in one sentence, and a
+  // substring check on the serving region alone passes even if the two are swapped.
+  it('sends an NA token on an EU deployment to the NA endpoint', async () => {
+    process.env.LLAMA_CLOUD_REGION = 'eu';
+    const { authErrorMessage } = await load();
+
+    expect(authErrorMessage(KEY_ERR, NA_TOKEN)).toBe(NA_HINT);
+  });
+
+  it('sends an EU token on an NA deployment to the EU endpoint', async () => {
+    process.env.LLAMA_CLOUD_REGION = 'na';
+    const { authErrorMessage } = await load();
+
+    expect(authErrorMessage(KEY_ERR, EU_TOKEN)).toBe(EU_HINT);
+  });
+
+  it('defaults to NA, so an unset region still recognises an EU token', async () => {
+    delete process.env.LLAMA_CLOUD_REGION;
+    const { authErrorMessage } = await load();
+
+    expect(authErrorMessage(KEY_ERR, EU_TOKEN)).toBe(EU_HINT);
+  });
+
+  it('matches a sibling issuer carrying a trailing slash', async () => {
+    process.env.LLAMA_CLOUD_REGION = 'na';
+    const { authErrorMessage } = await load();
+
+    expect(
+      authErrorMessage(
+        KEY_ERR,
+        tokenIssuedBy('https://login.eu.llamaindex.ai/')
+      )
+    ).toBe(EU_HINT);
+  });
+
+  // A cross-region token cannot normally reach a signature check — the key sets
+  // are disjoint — but a rotation that briefly overlaps them should still land
+  // on the helpful message.
+  it('also covers a signature failure', async () => {
+    process.env.LLAMA_CLOUD_REGION = 'na';
+    const { authErrorMessage } = await load();
+
+    expect(
+      authErrorMessage(
+        { code: 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED' },
+        EU_TOKEN
+      )
+    ).toBe(EU_HINT);
+  });
+
+  describe('issuers that must not be treated as the sibling', () => {
+    beforeEach(() => {
+      process.env.LLAMA_CLOUD_REGION = 'na';
+    });
+
+    it.each([
+      ['its own region', NA_TOKEN],
+      ['a third-party issuer', tokenIssuedBy('https://api.workos.com')],
+      [
+        'a lookalike host',
+        tokenIssuedBy('https://login.eu.llamaindex.ai.evil.com'),
+      ],
+      // `new URL('blob:https://host/x').origin` is `https://host`.
+      [
+        'a blob: URL wrapping the sibling',
+        tokenIssuedBy('blob:https://login.eu.llamaindex.ai/x'),
+      ],
+      ['plain http', tokenIssuedBy('http://login.eu.llamaindex.ai')],
+      ['no iss claim', tokenIssuedBy(undefined)],
+      ['a non-string iss', tokenIssuedBy(12345)],
+      [
+        'an object iss',
+        tokenIssuedBy({ url: 'https://login.eu.llamaindex.ai' }),
+      ],
+    ])('ignores %s', async (_label, token) => {
+      const { authErrorMessage } = await load();
+
+      expect(authErrorMessage(KEY_ERR, token)).toBe(UNVERIFIABLE);
+    });
+  });
+
+  // The adapter interpolates this message into a quoted WWW-Authenticate value
+  // with no escaping, and some jose messages embed caller-controlled text.
+  describe('never returns text it does not own', () => {
+    beforeEach(() => {
+      process.env.LLAMA_CLOUD_REGION = 'na';
+    });
+
+    it.each([
+      ['ERR_JWT_EXPIRED', '"exp" claim timestamp check failed', EXPIRED],
+      [
+        'ERR_JOSE_NOT_SUPPORTED',
+        'Extension Header Parameter "\\", resource_metadata="https://evil" is not recognized',
+        GENERIC,
+      ],
+      [
+        'ERR_JWT_CLAIM_VALIDATION_FAILED',
+        'unexpected "iss" claim value',
+        GENERIC,
+      ],
+      ['ERR_JWS_INVALID', 'Invalid Compact JWS', UNVERIFIABLE],
+    ])('replaces the %s message', async (code, message, expected) => {
+      const { authErrorMessage } = await load();
+
+      expect(authErrorMessage({ code, message }, EU_TOKEN)).toBe(expected);
+    });
+
+    it('emits no character that breaks the header grammar', async () => {
+      const { authErrorMessage } = await load();
+      const hostile = {
+        code: 'ERR_JOSE_NOT_SUPPORTED',
+        message: 'x", resource_metadata="https://evil.example\r\nX-Injected: 1',
+      };
+
+      expect(authErrorMessage(hostile, EU_TOKEN)).not.toMatch(/["\r\n\\]/);
+    });
+  });
+
+  describe('credentials and errors that carry no usable code', () => {
+    beforeEach(() => {
+      process.env.LLAMA_CLOUD_REGION = 'na';
+    });
+
+    it.each([
+      ['a malformed token', 'not-a-jwt'],
+      ['a payload that is not base64', 'aaa.!!!!.ccc'],
+      [
+        'a payload that is not JSON',
+        `aaa.${Buffer.from('nope').toString('base64url')}.ccc`,
+      ],
+      [
+        'a payload that is a JSON array',
+        `aaa.${Buffer.from('[]').toString('base64url')}.ccc`,
+      ],
+      ['an empty token', ''],
+    ])('falls back to the generic message for %s', async (_label, token) => {
+      const { authErrorMessage } = await load();
+
+      expect(authErrorMessage(KEY_ERR, token)).toBe(UNVERIFIABLE);
+    });
+
+    it.each([
+      ['an error with no code', {}],
+      ['undefined', undefined],
+      ['an Error instance', new Error('boom')],
+    ])('falls back for %s', async (_label, error) => {
+      const { authErrorMessage } = await load();
+
+      expect(authErrorMessage(error)).toBe(GENERIC);
+    });
+
+    it('does not resolve a region hint on a misconfigured deployment', async () => {
+      process.env.LLAMA_CLOUD_REGION = 'not-a-region';
+      const { authErrorMessage } = await load();
+
+      expect(authErrorMessage(KEY_ERR, EU_TOKEN)).toBe(UNVERIFIABLE);
+    });
+  });
+});
+
+// The adapter renders only InvalidTokenError as a 401 carrying the message;
+// anything else becomes an opaque 500, which is what this replaced.
+describe('invalidTokenError', () => {
+  it('produces an InvalidTokenError carrying the message', async () => {
+    process.env.LLAMA_CLOUD_REGION = 'na';
+    const { invalidTokenError } = await load();
+    // Imported through the same registry as the module under test: after
+    // jest.resetModules() a statically imported class is a different object.
+    const { InvalidTokenError } =
+      await import('@modelcontextprotocol/sdk/server/auth/errors.js');
+
+    const err = invalidTokenError(KEY_ERR, EU_TOKEN);
+
+    expect(err).toBeInstanceOf(InvalidTokenError);
+    expect(err.errorCode).toBe('invalid_token');
+    expect(err.message).toBe(EU_HINT);
+  });
+});

--- a/__tests__/token-errors.test.ts
+++ b/__tests__/token-errors.test.ts
@@ -143,20 +143,50 @@ describe('authErrorMessage', () => {
         GENERIC,
       ],
       ['ERR_JWS_INVALID', 'Invalid Compact JWS', UNVERIFIABLE],
+      ['ERR_JWT_INVALID', 'Invalid JWT', UNVERIFIABLE],
     ])('replaces the %s message', async (code, message, expected) => {
       const { authErrorMessage } = await load();
 
       expect(authErrorMessage({ code, message }, EU_TOKEN)).toBe(expected);
     });
 
-    it('emits no character that breaks the header grammar', async () => {
+    // Asserted by equality, not by scanning for header metacharacters: a
+    // passthrough whose text happens to contain none of them would pass that.
+    it('never echoes an attacker-supplied crit parameter', async () => {
       const { authErrorMessage } = await load();
       const hostile = {
         code: 'ERR_JOSE_NOT_SUPPORTED',
         message: 'x", resource_metadata="https://evil.example\r\nX-Injected: 1',
       };
 
-      expect(authErrorMessage(hostile, EU_TOKEN)).not.toMatch(/["\r\n\\]/);
+      expect(authErrorMessage(hostile, EU_TOKEN)).toBe(GENERIC);
+    });
+  });
+
+  // `jwtVerify` fetches the remote JWKS, so a WorkOS outage surfaces from the
+  // same call as a bad signature. Answering those with `invalid_token` would
+  // send every client to re-authenticate against the WorkOS that is down.
+  describe('server faults are not the token’s fault', () => {
+    beforeEach(() => {
+      process.env.LLAMA_CLOUD_REGION = 'na';
+    });
+
+    it.each([
+      ['a JWKS non-200', 'ERR_JOSE_GENERIC'],
+      ['a JWKS timeout', 'ERR_JWKS_TIMEOUT'],
+      ['a malformed JWKS', 'ERR_JWKS_INVALID'],
+      ['an ambiguous JWKS', 'ERR_JWKS_MULTIPLE_MATCHING_KEYS'],
+    ])('returns undefined for %s', async (_label, code) => {
+      const { authErrorMessage, invalidTokenError } = await load();
+
+      expect(authErrorMessage({ code }, EU_TOKEN)).toBeUndefined();
+      expect(invalidTokenError({ code }, EU_TOKEN)).toBeUndefined();
+    });
+
+    it('returns undefined for a transport error carrying no code', async () => {
+      const { authErrorMessage } = await load();
+
+      expect(authErrorMessage(new TypeError('fetch failed'))).toBeUndefined();
     });
   });
 
@@ -183,14 +213,17 @@ describe('authErrorMessage', () => {
       expect(authErrorMessage(KEY_ERR, token)).toBe(UNVERIFIABLE);
     });
 
+    // An error with no code is not attributable to the token, so the caller
+    // rethrows it and the adapter renders a 500.
     it.each([
       ['an error with no code', {}],
       ['undefined', undefined],
       ['an Error instance', new Error('boom')],
-    ])('falls back for %s', async (_label, error) => {
+      ['an unrecognised code', { code: 'ERR_SOMETHING_NEW' }],
+    ])('declines to classify %s', async (_label, error) => {
       const { authErrorMessage } = await load();
 
-      expect(authErrorMessage(error)).toBe(GENERIC);
+      expect(authErrorMessage(error)).toBeUndefined();
     });
 
     it('does not resolve a region hint on a misconfigured deployment', async () => {
@@ -216,7 +249,7 @@ describe('invalidTokenError', () => {
     const err = invalidTokenError(KEY_ERR, EU_TOKEN);
 
     expect(err).toBeInstanceOf(InvalidTokenError);
-    expect(err.errorCode).toBe('invalid_token');
-    expect(err.message).toBe(EU_HINT);
+    expect(err?.errorCode).toBe('invalid_token');
+    expect(err?.message).toBe(EU_HINT);
   });
 });

--- a/lib/auth/token-errors.ts
+++ b/lib/auth/token-errors.ts
@@ -12,10 +12,11 @@ import { regionProfile, siblingProfile } from '../region';
  * The signature code is included so a key rotation that briefly leaves the two
  * sets overlapping still reaches the helpful message.
  */
-const UNVERIFIABLE_TOKEN_CODES = new Set([
+const UNVERIFIABLE_CODES = [
   'ERR_JWKS_NO_MATCHING_KEY',
   'ERR_JWS_SIGNATURE_VERIFICATION_FAILED',
-]);
+] as const;
+const UNVERIFIABLE_TOKEN_CODES = new Set<string>(UNVERIFIABLE_CODES);
 
 const EXPIRED = 'Your session has expired. Please sign in again.';
 const UNVERIFIABLE = 'Invalid token signature. Please sign in again.';
@@ -32,11 +33,12 @@ const GENERIC = 'Authentication failed. Please sign in again.';
  * merely embed quotes that break the header grammar. Nothing outside this file
  * reaches a client; the full error still goes to the log.
  */
-const OWNED_MESSAGES = new Map([
+const OWNED = [
   ['ERR_JWT_EXPIRED', EXPIRED],
   ['ERR_JWS_INVALID', UNVERIFIABLE],
   ['ERR_JWT_INVALID', UNVERIFIABLE],
-]);
+] as const;
+const OWNED_MESSAGES = new Map<string, string>(OWNED);
 
 function httpsOriginOf(value: string): string | undefined {
   try {
@@ -87,17 +89,39 @@ function tokenBelongsToSibling(token: string, sibling: RegionLabels): boolean {
 type RegionLabels = ReturnType<typeof siblingProfile>;
 
 /**
- * The message an MCP client sees when its token is rejected.
+ * Codes that mean the *presented token* is at fault.
+ *
+ * An allow-list, because `jwtVerify` also fetches the remote JWKS: a WorkOS
+ * outage, a timeout or a DNS failure surfaces from the same call as a bad
+ * signature. Those are server faults, and answering them with `invalid_token`
+ * would tell every client holding a good credential to re-authenticate —
+ * against the same WorkOS that is down. Narrowing the caller's `try` cannot
+ * separate them; only the code can.
+ */
+const TOKEN_FAULT_CODES = new Set<string>([
+  ...UNVERIFIABLE_CODES,
+  ...OWNED.map(([code]) => code),
+  'ERR_JWT_CLAIM_VALIDATION_FAILED',
+  // The `crit` header the client sent names a parameter this server does not
+  // implement — malformed input, not a server problem.
+  'ERR_JOSE_NOT_SUPPORTED',
+]);
+
+/**
+ * The message an MCP client sees when its token is rejected, or `undefined`
+ * when the failure was not the token's fault and the caller should let the
+ * error surface as a server error.
  *
  * An expired token and a wrong-region token look identical to a user and have
- * completely different fixes, so only the second gets the region wording —
- * sending someone whose session merely lapsed to another server points them at
- * a region their account does not exist in.
+ * completely different fixes, so only the second gets the region wording.
  */
-export function authErrorMessage(error: unknown, token?: string): string {
+export function authErrorMessage(
+  error: unknown,
+  token?: string
+): string | undefined {
   const { code } = (error ?? {}) as { code?: string };
-  if (!code) {
-    return GENERIC;
+  if (!code || !TOKEN_FAULT_CODES.has(code)) {
+    return undefined;
   }
 
   if (UNVERIFIABLE_TOKEN_CODES.has(code)) {
@@ -125,14 +149,19 @@ export function authErrorMessage(error: unknown, token?: string): string {
 }
 
 /**
- * `InvalidTokenError`, not a bare `Error`: the adapter renders only this type
- * as a 401 carrying the message in `WWW-Authenticate`, which is both what the
- * client shows and the signal telling it to re-authenticate. Anything else it
- * does not recognise becomes an opaque 500 and the message is lost.
+ * The error to throw for a rejected token, or `undefined` when the failure was
+ * not the token's fault.
+ *
+ * `InvalidTokenError` because the adapter renders only this type as a 401
+ * carrying the message in `WWW-Authenticate`, which is both what the client
+ * shows and the signal telling it to re-authenticate. Anything else it does not
+ * recognise becomes an opaque 500 — which is the right answer for a server
+ * fault, and the reason this returns `undefined` rather than guessing.
  */
 export function invalidTokenError(
   error: unknown,
   token?: string
-): InvalidTokenError {
-  return new InvalidTokenError(authErrorMessage(error, token));
+): InvalidTokenError | undefined {
+  const message = authErrorMessage(error, token);
+  return message === undefined ? undefined : new InvalidTokenError(message);
 }

--- a/lib/auth/token-errors.ts
+++ b/lib/auth/token-errors.ts
@@ -1,0 +1,138 @@
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { regionProfile, siblingProfile } from '../region';
+
+/**
+ * jose codes meaning the token could not be tied to one of this region's
+ * signing keys.
+ *
+ * `ERR_JWKS_NO_MATCHING_KEY` is the one a wrong-region token actually produces:
+ * the regions are separate WorkOS environments with disjoint key sets, and
+ * `jwtVerify` resolves the key by `kid` before it checks the signature and long
+ * before it validates any claim — so an `issuer` option would never fire here.
+ * The signature code is included so a key rotation that briefly leaves the two
+ * sets overlapping still reaches the helpful message.
+ */
+const UNVERIFIABLE_TOKEN_CODES = new Set([
+  'ERR_JWKS_NO_MATCHING_KEY',
+  'ERR_JWS_SIGNATURE_VERIFICATION_FAILED',
+]);
+
+const EXPIRED = 'Your session has expired. Please sign in again.';
+const UNVERIFIABLE = 'Invalid token signature. Please sign in again.';
+const GENERIC = 'Authentication failed. Please sign in again.';
+
+/**
+ * Messages this module owns, keyed by the error code that earns them.
+ *
+ * The set is closed on purpose. `@vercel/mcp-adapter` interpolates whatever it
+ * is given into a quoted `WWW-Authenticate` value with no escaping, and some
+ * jose messages embed caller-controlled text — `ERR_JOSE_NOT_SUPPORTED` quotes
+ * an unrecognised `crit` header parameter name straight from the request, which
+ * would let an unauthenticated caller inject their own auth-params. Others
+ * merely embed quotes that break the header grammar. Nothing outside this file
+ * reaches a client; the full error still goes to the log.
+ */
+const OWNED_MESSAGES = new Map([
+  ['ERR_JWT_EXPIRED', EXPIRED],
+  ['ERR_JWS_INVALID', UNVERIFIABLE],
+  ['ERR_JWT_INVALID', UNVERIFIABLE],
+]);
+
+function httpsOriginOf(value: string): string | undefined {
+  try {
+    const url = new URL(value);
+    // Scheme-checked because `new URL('blob:https://host/x').origin` is
+    // `https://host`, which would otherwise match a region.
+    return url.protocol === 'https:' ? url.origin.toLowerCase() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The `iss` claim of a JWT, read without verifying it.
+ *
+ * Hand-decoded rather than via jose's `decodeJwt` only because jose is ESM-only
+ * and `next/jest` will not transform it, which would leave this module
+ * untestable.
+ */
+function unverifiedIssuer(token: string): string | undefined {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  try {
+    const json = Buffer.from(parts[1], 'base64url').toString('utf8');
+    const { iss } = JSON.parse(json) as { iss?: unknown };
+    return typeof iss === 'string' ? iss : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Trusting an unverified claim is safe here and nowhere else: this runs only
+ * after verification has already failed, it chooses the wording of a rejection,
+ * and nothing downstream treats the request as authenticated. Forging `iss`
+ * changes only the error text the forger receives.
+ */
+function tokenBelongsToSibling(token: string, sibling: RegionLabels): boolean {
+  const iss = unverifiedIssuer(token);
+  return (
+    iss !== undefined &&
+    httpsOriginOf(iss) === sibling.authkitIssuerOrigin.toLowerCase()
+  );
+}
+
+type RegionLabels = ReturnType<typeof siblingProfile>;
+
+/**
+ * The message an MCP client sees when its token is rejected.
+ *
+ * An expired token and a wrong-region token look identical to a user and have
+ * completely different fixes, so only the second gets the region wording —
+ * sending someone whose session merely lapsed to another server points them at
+ * a region their account does not exist in.
+ */
+export function authErrorMessage(error: unknown, token?: string): string {
+  const { code } = (error ?? {}) as { code?: string };
+  if (!code) {
+    return GENERIC;
+  }
+
+  if (UNVERIFIABLE_TOKEN_CODES.has(code)) {
+    // Resolving the region can itself throw on a misconfigured deployment, and
+    // this runs inside a catch block.
+    let sibling: RegionLabels | undefined;
+    let serving: string | undefined;
+    try {
+      sibling = siblingProfile();
+      serving = regionProfile().label;
+    } catch {
+      return UNVERIFIABLE;
+    }
+
+    if (token && tokenBelongsToSibling(token, sibling)) {
+      return (
+        `This token was issued for the ${sibling.label} region, but this server serves ${serving}. ` +
+        `If your LlamaCloud account is at ${sibling.consoleUrl}, connect to ${sibling.mcpUrl}/mcp instead.`
+      );
+    }
+    return UNVERIFIABLE;
+  }
+
+  return OWNED_MESSAGES.get(code) ?? GENERIC;
+}
+
+/**
+ * `InvalidTokenError`, not a bare `Error`: the adapter renders only this type
+ * as a 401 carrying the message in `WWW-Authenticate`, which is both what the
+ * client shows and the signal telling it to re-authenticate. Anything else it
+ * does not recognise becomes an opaque 500 and the message is lost.
+ */
+export function invalidTokenError(
+  error: unknown,
+  token?: string
+): InvalidTokenError {
+  return new InvalidTokenError(authErrorMessage(error, token));
+}

--- a/lib/mcp/handler.ts
+++ b/lib/mcp/handler.ts
@@ -3,7 +3,7 @@ import {
   experimental_withMcpAuth,
 } from '@vercel/mcp-adapter';
 import { getWorkOS } from '@workos-inc/authkit-nextjs';
-import { jwtVerify, createRemoteJWKSet } from 'jose';
+import { jwtVerify, createRemoteJWKSet, type JWTPayload } from 'jose';
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { User, WorkOSAuthInfo } from '@/lib/auth/types';
 import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
@@ -86,16 +86,21 @@ export function buildMcpRouteHandler(
         return undefined;
       }
 
-      // Only token verification is converted to a 401. A WorkOS or rate-limiter
-      // fault below is a server problem, and reporting it as `invalid_token`
-      // would tell a user holding a perfectly good credential to re-authenticate
-      // — a loop they cannot exit. Those propagate and the adapter renders a 500.
-      let payload;
+      // Only a fault in the token itself becomes a 401. Everything else here is
+      // a server problem — including a JWKS fetch failure, which surfaces from
+      // `jwtVerify` alongside real signature errors — and answering those with
+      // `invalid_token` would tell users holding good credentials to
+      // re-authenticate against the same WorkOS that is down.
+      let payload: JWTPayload;
       try {
         ({ payload } = await jwtVerify(token, JWKS));
       } catch (error: unknown) {
         logger.error('Token verification failed:', error);
-        throw invalidTokenError(error, token);
+        const rejection = invalidTokenError(error, token);
+        if (!rejection) {
+          throw error;
+        }
+        throw rejection;
       }
 
       if (!payload.sub) {

--- a/lib/mcp/handler.ts
+++ b/lib/mcp/handler.ts
@@ -4,10 +4,12 @@ import {
 } from '@vercel/mcp-adapter';
 import { getWorkOS } from '@workos-inc/authkit-nextjs';
 import { jwtVerify, createRemoteJWKSet } from 'jose';
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { User, WorkOSAuthInfo } from '@/lib/auth/types';
 import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
 import { getLogger } from '@/lib/observability/logger';
 import { extractRateLimitFromResponse } from '@/lib/auth/helpers';
+import { invalidTokenError } from '@/lib/auth/token-errors';
 import type { McpServer } from '@/lib/mcp/tools/tools';
 
 const workos = getWorkOS();
@@ -84,51 +86,47 @@ export function buildMcpRouteHandler(
         return undefined;
       }
 
+      // Only token verification is converted to a 401. A WorkOS or rate-limiter
+      // fault below is a server problem, and reporting it as `invalid_token`
+      // would tell a user holding a perfectly good credential to re-authenticate
+      // — a loop they cannot exit. Those propagate and the adapter renders a 500.
+      let payload;
       try {
-        const { payload } = await jwtVerify(token, JWKS);
+        ({ payload } = await jwtVerify(token, JWKS));
+      } catch (error: unknown) {
+        logger.error('Token verification failed:', error);
+        throw invalidTokenError(error, token);
+      }
 
-        if (!payload.sub) {
-          throw new Error('Invalid token: missing sub claim');
-        }
+      if (!payload.sub) {
+        logger.error('Token carried no sub claim');
+        throw new InvalidTokenError('Invalid token. Please sign in again.');
+      }
 
-        const userProfile = await workos.userManagement.getUser(payload.sub);
+      const userProfile = await workos.userManagement.getUser(payload.sub);
 
-        const user: User = {
-          id: userProfile.id,
-          email: userProfile.email,
-          firstName: userProfile.firstName,
-          lastName: userProfile.lastName,
-          profilePictureUrl: userProfile.profilePictureUrl,
-        };
+      const user: User = {
+        id: userProfile.id,
+        email: userProfile.email,
+        firstName: userProfile.firstName,
+        lastName: userProfile.lastName,
+        profilePictureUrl: userProfile.profilePictureUrl,
+      };
 
-        request.headers.set('x-user-id', userProfile.id);
-        const limiterResponse = await applyRateLimit(request);
+      request.headers.set('x-user-id', userProfile.id);
+      const limiterResponse = await applyRateLimit(request);
 
-        const workosAuthInfo: WorkOSAuthInfo = {
+      logger.debug('Token validated and ready to get passed through');
+      return {
+        token,
+        clientId: clientId!,
+        scopes: [],
+        extra: {
           user,
           claims: payload,
           rateLimit: extractRateLimitFromResponse(limiterResponse),
-        };
-
-        logger.debug('Token validated and ready to get passed through');
-        return {
-          token,
-          clientId: clientId!,
-          scopes: [],
-          extra: workosAuthInfo,
-        };
-      } catch (error: unknown) {
-        console.error('Authentication error:', error);
-        const errorObj = error as { code?: string; message?: string };
-        const errorMessage =
-          errorObj.code === 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED'
-            ? 'Invalid token signature. Please sign in again.'
-            : errorObj.message ||
-              'Authentication failed. Please sign in again.';
-
-        // eslint-disable-next-line preserve-caught-error
-        throw new Error(errorMessage);
-      }
+        } satisfies WorkOSAuthInfo,
+      };
     },
     {
       required: false,

--- a/lib/region.ts
+++ b/lib/region.ts
@@ -15,9 +15,19 @@ export class RegionConfigError extends Error {
   }
 }
 
-type RegionProfile = {
+export type RegionProfile = {
   readonly label: string;
   readonly apiBaseUrl: string;
+  /** Only read for the region a deployment is *not* serving. */
+  readonly consoleUrl: string;
+  readonly mcpUrl: string;
+  /**
+   * Recognises the `iss` of a token this deployment cannot verify. Distinct
+   * from `authkitOrigin()` in lib/authkit.ts, which resolves *this*
+   * deployment's issuer from `WORKOS_AUTHKIT_DOMAIN` — a sibling's origin
+   * cannot be learned from this deployment's environment, so it is stated here.
+   */
+  readonly authkitIssuerOrigin: string;
   /**
    * Vercel regions whose compute satisfies this region's residency commitment.
    * Documents are terminated and parsed inside the function, so the API host
@@ -25,10 +35,10 @@ type RegionProfile = {
    *
    * Only `eu` is constrained: it is the region with a published commitment
    * ("all data provided will remain within the EU region for storage and
-   * processing"). Deliberately excludes lhr1 and zrh1 — the UK and Switzerland
-   * hold adequacy decisions but are not in the EU. `na` is left unconstrained
-   * because there is no equivalent commitment and the existing deployment does
-   * not pin a function region.
+   * processing"). Deliberately excludes lhr1 — the UK holds an adequacy
+   * decision but is not in the EU. `na` is left unconstrained because there is
+   * no equivalent commitment and the existing deployment does not pin a
+   * function region.
    */
   readonly computeRegions?: readonly string[];
 };
@@ -37,10 +47,16 @@ const PROFILES: Record<Region, RegionProfile> = Object.freeze({
   na: Object.freeze({
     label: 'North America (NA)',
     apiBaseUrl: 'https://api.cloud.llamaindex.ai',
+    consoleUrl: 'https://cloud.llamaindex.ai',
+    mcpUrl: 'https://mcp.llamaindex.ai',
+    authkitIssuerOrigin: 'https://login.llamaindex.ai',
   }),
   eu: Object.freeze({
     label: 'Europe (EU)',
     apiBaseUrl: 'https://api.cloud.eu.llamaindex.ai',
+    consoleUrl: 'https://cloud.eu.llamaindex.ai',
+    mcpUrl: 'https://mcp.eu.llamaindex.ai',
+    authkitIssuerOrigin: 'https://login.eu.llamaindex.ai',
     computeRegions: Object.freeze(['fra1', 'cdg1', 'arn1', 'dub1']),
   }),
 });
@@ -169,6 +185,11 @@ export function getRegion(): Region {
 
 export function regionProfile(): RegionProfile {
   return PROFILES[getRegion()];
+}
+
+/** The region this deployment does *not* serve. */
+export function siblingProfile(): RegionProfile {
+  return PROFILES[getRegion() === 'eu' ? 'na' : 'eu'];
 }
 
 export function llamaCloudBaseUrl(): string {


### PR DESCRIPTION
Part of LI-8474. Targets `main` directly — #18/#19/#20 are all merged, so this does not stack.

## Why

NA and EU are separate WorkOS environments with **disjoint JWKS**. An EU account's token presented to the NA server is rejected outright — not slower, it cannot authenticate at all. Until now that surfaced as jose's own text, `no applicable key found in the JSON Web Key Set`, with no hint that the account simply lives in the other region.

## The mechanic that shapes the fix

An `issuer` option on `jwtVerify` **cannot** deliver this. jose resolves the signing key by `kid` (`jwt/verify.js:5` → `compactVerify`) *before* it checks the signature and long before `validateClaimsSet` runs, so a wrong-region token dies at `ERR_JWKS_NO_MATCHING_KEY` and never reaches a claim check.

The message is therefore built from the key-resolution failure, reading `iss` off the already-rejected token to identify the sibling. Trusting that unverified claim is safe *here and nowhere else*: it only selects error wording, and nothing downstream treats the request as authenticated — forging `iss` changes only the text the forger receives.

## Three things fall out of getting this to a client at all

**1. The message never reached anyone.** The handler threw a bare `Error`; `@vercel/mcp-adapter` (`dist/index.mjs:38-69`) renders only `InvalidTokenError` as a 401 carrying the message in `WWW-Authenticate` — anything else becomes an opaque `{"error":"server_error"}` 500. So the pre-existing "Invalid token signature. Please sign in again." copy had **never been seen by a user either**. 401 + `resource_metadata` is also the signal MCP clients use to start re-authentication.

**2. That header is interpolated unescaped, and some jose messages embed caller-controlled input.** `ERR_JOSE_NOT_SUPPORTED` reads `Extension Header Parameter "${parameter}" is not recognized`, where `parameter` is an unrecognised `crit` header name taken straight from the request, and `validateCrit` runs before any verification. Passing library text through would let an unauthenticated caller close the quote and append their own `resource_metadata="https://attacker…"`, which MCP clients prefer over the server's own.

> **This is not a live vulnerability on `main`.** Today's bare `Error` produces no `WWW-Authenticate` header at all, so there is nothing to inject into. Converting to `InvalidTokenError` is what would open the path — which is why the closed message set ships in the same PR rather than as a follow-up. Every string this module can return is a literal it owns; the full error still goes to the log.

**3. Only a fault in the token itself becomes a 401.** `jwtVerify` also fetches the remote JWKS, so a WorkOS outage, a JWKS timeout or a DNS failure arrives from the same call as a bad signature. Those are classified by error code, not by position in the `try`, and rethrown so the adapter renders a 500 — otherwise an outage would tell every client holding a good credential to re-authenticate against the WorkOS that is down, and would vanish from 5xx metrics.

## Verified against running servers

```
NA server + EU token          → 401  "…connect to https://mcp.eu.llamaindex.ai/mcp instead."
EU server + NA token          → 401  …mirrored…
forged `crit` payload         → 401  "Authentication failed. Please sign in again."
                                     (server's own resource_metadata intact)
JWKS unreachable, good token  → 500  server_error   ← was 401 before the classification fix
```

157 tests (was 122 on `main`); tsc, eslint, prettier clean.

## Notes for the reviewer

- `lib/region.ts` gains `consoleUrl` / `mcpUrl` / `authkitIssuerOrigin` per region. `authkitIssuerOrigin` is deliberately **not** the source of this deployment's own issuer — that stays `WORKOS_AUTHKIT_DOMAIN` via `authkitOrigin()`, so local and preview deployments pointed at another AuthKit environment keep working. A sibling's origin cannot be learned from this deployment's environment, so it is stated.
- The same commit drops a stale `zrh1`/Switzerland clause from the residency comment — Vercel has no Zurich region, so there was nothing to exclude.
- **The EU host this message advertises is not live yet** (`mcp.eu.llamaindex.ai` is NXDOMAIN, pending Phase 2 of the EU plan). Shipping anyway is still net-positive: today the user gets an unexplained key error, and after this they are told the cause and the region their account belongs to. The companion console PR is gated on that DNS record; this one is not, because it only names the destination in an error message.
- `lib/mcp/handler.ts` still has no test of its own; the classification logic it calls is covered directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kf3KMnh4BEJQTVFpVHwuoz