### PR TITLE
Account for every tool call, and report it to PostHog

### DIFF
--- a/__tests__/organization.test.ts
+++ b/__tests__/organization.test.ts
@@ -1,0 +1,150 @@
+import {
+  clearOrganizationCache,
+  resolveOrganizationId,
+} from '../lib/business/organization';
+import { llamaCloudClient } from '../lib/business/client';
+
+jest.mock('../lib/business/client', () => ({
+  llamaCloudClient: jest.fn(),
+}));
+
+const mockedClient = llamaCloudClient as jest.MockedFunction<
+  typeof llamaCloudClient
+>;
+
+type FakeProject = {
+  id: string;
+  organization_id: string;
+  is_default?: boolean;
+};
+
+const PROJECTS: FakeProject[] = [
+  { id: 'proj_a', organization_id: 'org_a' },
+  { id: 'proj_b', organization_id: 'org_b', is_default: true },
+];
+
+/** Stub the two calls the resolver can make, so each test can assert which ran. */
+function stubClient({
+  projects = PROJECTS,
+  getError,
+}: {
+  projects?: FakeProject[];
+  getError?: Error;
+} = {}) {
+  const get = jest.fn((id: string) => {
+    if (getError) {
+      return Promise.reject(getError);
+    }
+    const project = projects.find((p) => p.id === id);
+    return project
+      ? Promise.resolve(project)
+      : Promise.reject(new Error('404 project not found'));
+  });
+  const list = jest.fn(() => Promise.resolve(projects));
+  mockedClient.mockReturnValue({
+    projects: { get, list },
+  } as unknown as ReturnType<typeof llamaCloudClient>);
+  return { get, list };
+}
+
+describe('resolveOrganizationId', () => {
+  beforeEach(() => {
+    clearOrganizationCache();
+    jest.clearAllMocks();
+  });
+
+  it('fetches a named project directly instead of searching a listing', async () => {
+    const { get, list } = stubClient();
+
+    await expect(
+      resolveOrganizationId({
+        authToken: 'token',
+        userId: 'user_1',
+        projectId: 'proj_a',
+      })
+    ).resolves.toBe('org_a');
+
+    expect(get).toHaveBeenCalledWith('proj_a', undefined, expect.anything());
+    // The listing is unbounded, so a named project must never depend on it.
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('uses the default project when none is named', async () => {
+    const { get, list } = stubClient();
+
+    await expect(
+      resolveOrganizationId({ authToken: 'token', userId: 'user_1' })
+    ).resolves.toBe('org_b');
+
+    expect(list).toHaveBeenCalled();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined rather than guessing when no project is marked default', async () => {
+    // Attributing to an arbitrary project would name the wrong organization,
+    // which is worse than recording nothing.
+    stubClient({ projects: [{ id: 'proj_a', organization_id: 'org_a' }] });
+
+    await expect(
+      resolveOrganizationId({ authToken: 'token', userId: 'user_1' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns undefined for a project the caller cannot see', async () => {
+    stubClient();
+
+    await expect(
+      resolveOrganizationId({
+        authToken: 'token',
+        userId: 'user_1',
+        projectId: 'proj_missing',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('caches per project, since a user can span organizations', async () => {
+    const { get } = stubClient();
+
+    await resolveOrganizationId({
+      authToken: 'token',
+      userId: 'user_1',
+      projectId: 'proj_a',
+    });
+    await resolveOrganizationId({
+      authToken: 'token',
+      userId: 'user_1',
+      projectId: 'proj_a',
+    });
+    expect(get).toHaveBeenCalledTimes(1);
+
+    await expect(
+      resolveOrganizationId({
+        authToken: 'token',
+        userId: 'user_1',
+        projectId: 'proj_b',
+      })
+    ).resolves.toBe('org_b');
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades to undefined when the API fails, without caching the miss', async () => {
+    stubClient({ getError: new Error('api down') });
+    await expect(
+      resolveOrganizationId({
+        authToken: 'token',
+        userId: 'user_1',
+        projectId: 'proj_a',
+      })
+    ).resolves.toBeUndefined();
+
+    // A transient failure must not blind attribution until the TTL expires.
+    stubClient();
+    await expect(
+      resolveOrganizationId({
+        authToken: 'token',
+        userId: 'user_1',
+        projectId: 'proj_a',
+      })
+    ).resolves.toBe('org_a');
+  });
+});

--- a/__tests__/posthog.test.ts
+++ b/__tests__/posthog.test.ts
@@ -1,0 +1,129 @@
+import { PostHog } from 'posthog-node';
+import {
+  TOOL_CALL_EVENT,
+  captureToolUsage,
+  resetPostHogClient,
+} from '../lib/observability/posthog';
+import { UNKNOWN, type ToolUsageEvent } from '../lib/observability/usage-event';
+
+jest.mock('posthog-node', () => ({
+  PostHog: jest.fn(),
+}));
+
+const MockedPostHog = PostHog as unknown as jest.Mock;
+
+const captureImmediate = jest.fn(
+  (payload: Record<string, unknown>): Promise<void> => {
+    void payload;
+    return Promise.resolve();
+  }
+);
+
+/** The single captured payload, asserted to exist so callers can index it. */
+function firstCapture(): Record<string, unknown> {
+  expect(captureImmediate).toHaveBeenCalledTimes(1);
+  return captureImmediate.mock.calls[0]![0];
+}
+
+const EVENT: ToolUsageEvent = {
+  tool: 'parseFile',
+  surface: 'parse',
+  scoped: false,
+  region: 'na',
+  userId: 'user_01ABC',
+  projectId: 'proj_9',
+  organizationId: 'org_7',
+  outcome: 'success',
+  durationMs: 120,
+};
+
+describe('captureToolUsage', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.POSTHOG_HOST;
+    process.env.POSTHOG_API_KEY = 'phc_test';
+    process.env.VERCEL_ENV = 'production';
+    jest.clearAllMocks();
+    resetPostHogClient();
+    MockedPostHog.mockImplementation(() => ({ captureImmediate }));
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('sends the payload the platform’s own events are shaped like', async () => {
+    await captureToolUsage(EVENT);
+
+    expect(firstCapture()).toEqual({
+      // The WorkOS user id: what PostHog joins MCP usage to console and API
+      // activity on.
+      distinctId: 'user_01ABC',
+      event: TOOL_CALL_EVENT,
+      groups: { organization: 'org_7' },
+      properties: {
+        tool: 'parseFile',
+        surface: 'parse',
+        scoped: false,
+        region: 'na',
+        user_id: 'user_01ABC',
+        project_id: 'proj_9',
+        organization_id: 'org_7',
+        outcome: 'success',
+        duration_ms: 120,
+        environment: 'production',
+      },
+    });
+  });
+
+  it('omits the organization rather than sending a placeholder group', async () => {
+    await captureToolUsage({ ...EVENT, organizationId: UNKNOWN });
+
+    const call = firstCapture() as {
+      groups?: unknown;
+      properties: Record<string, unknown>;
+    };
+    expect(call.groups).toBeUndefined();
+    expect(call.properties).not.toHaveProperty('organization_id');
+  });
+
+  it('drops unauthenticated calls, which have no person to attribute', async () => {
+    await captureToolUsage({ ...EVENT, userId: UNKNOWN });
+
+    expect(captureImmediate).not.toHaveBeenCalled();
+  });
+
+  it('stays off when no key is configured', async () => {
+    delete process.env.POSTHOG_API_KEY;
+    resetPostHogClient();
+
+    await captureToolUsage(EVENT);
+
+    expect(MockedPostHog).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [undefined, 'https://us.i.posthog.com'],
+    ['http://localhost:8010', 'http://localhost:8010'],
+  ])('resolves POSTHOG_HOST=%p to %p', async (configured, expected) => {
+    if (configured) {
+      process.env.POSTHOG_HOST = configured;
+    }
+    resetPostHogClient();
+
+    await captureToolUsage(EVENT);
+
+    expect(MockedPostHog).toHaveBeenCalledWith(
+      'phc_test',
+      expect.objectContaining({ host: expected })
+    );
+  });
+
+  it('swallows a reporting failure so the tool call still succeeds', async () => {
+    captureImmediate.mockRejectedValueOnce(new Error('posthog down'));
+
+    await expect(captureToolUsage(EVENT)).resolves.toBeUndefined();
+  });
+});

--- a/__tests__/usage.test.ts
+++ b/__tests__/usage.test.ts
@@ -1,0 +1,195 @@
+import type { McpServer } from '@/lib/mcp/tools/tools';
+import {
+  UNKNOWN,
+  buildToolUsageEvent,
+  classifyOutcome,
+  instrumentToolUsage,
+  surfaceFromBasePath,
+} from '../lib/observability/usage';
+
+const USER = { id: 'user_01ABC' };
+
+function authInfo(extra: Record<string, unknown> | undefined) {
+  return {
+    token: 'token',
+    clientId: 'client',
+    scopes: [],
+    extra,
+  } as unknown as Parameters<typeof classifyOutcome>[0]['authInfo'];
+}
+
+const AUTHENTICATED = authInfo({
+  user: USER,
+  claims: {},
+  rateLimit: undefined,
+});
+const RATE_LIMITED = authInfo({
+  user: USER,
+  claims: {},
+  rateLimit: 'Too many requests. Retry in 30 seconds.',
+});
+
+describe('surfaceFromBasePath', () => {
+  // `/index/[indexId]` and `/classify/[configId]` embed caller-controlled ids;
+  // recording them verbatim would make the label unbounded.
+  it.each([
+    ['', 'full', false],
+    ['/parse', 'parse', false],
+    ['/index/idx_0199', 'index', true],
+    ['/classify/cfg_42', 'classify', true],
+  ])('labels %p as %p', (basePath, surface, scoped) => {
+    expect(surfaceFromBasePath(basePath)).toEqual({ surface, scoped });
+  });
+});
+
+describe('classifyOutcome', () => {
+  it.each([
+    ['success', AUTHENTICATED, { content: [] }, false],
+    ['tool_error', AUTHENTICATED, { content: [], isError: true }, false],
+    ['rate_limited', RATE_LIMITED, { content: [], isError: true }, false],
+    ['exception', AUTHENTICATED, undefined, true],
+    ['unauthenticated', authInfo({ claims: {} }), { content: [] }, false],
+    ['unauthenticated', undefined, undefined, true],
+  ])('reports %s', (expected, auth, result, threw) => {
+    expect(
+      classifyOutcome({
+        authInfo: auth as Parameters<typeof classifyOutcome>[0]['authInfo'],
+        result,
+        threw,
+      })
+    ).toBe(expected);
+  });
+});
+
+describe('buildToolUsageEvent', () => {
+  const base = {
+    tool: 'parseFile',
+    surface: { surface: 'parse', scoped: false },
+    organizationId: 'org_7',
+    outcome: 'success' as const,
+    durationMs: 120,
+  };
+
+  it('carries the caller identity and the target project', () => {
+    const event = buildToolUsageEvent({
+      ...base,
+      authInfo: AUTHENTICATED,
+      toolArgs: { fileId: 'file_1', projectId: 'proj_9' },
+    });
+
+    expect(event).toEqual({
+      tool: 'parseFile',
+      surface: 'parse',
+      scoped: false,
+      region: 'na',
+      userId: USER.id,
+      projectId: 'proj_9',
+      organizationId: 'org_7',
+      outcome: 'success',
+      durationMs: 120,
+    });
+  });
+
+  it('fills every dimension when nothing is resolvable', () => {
+    const event = buildToolUsageEvent({
+      ...base,
+      authInfo: undefined,
+      // A non-string projectId is as unusable as an absent one.
+      toolArgs: { projectId: 42 },
+      organizationId: undefined,
+    });
+
+    expect(event).toMatchObject({
+      userId: UNKNOWN,
+      projectId: UNKNOWN,
+      organizationId: UNKNOWN,
+    });
+  });
+});
+
+describe('instrumentToolUsage', () => {
+  type ToolCallback = (...args: unknown[]) => unknown;
+
+  function fakeServer() {
+    const registrations: unknown[][] = [];
+    const server = {
+      tool: (...args: unknown[]) => {
+        registrations.push(args);
+      },
+      unrelated: () => 'passed through',
+    };
+    return { server, registrations };
+  }
+
+  /** The wrapped callback the instrumented server handed to the real one. */
+  function registeredCallback(registration: unknown[]): ToolCallback {
+    return registration[registration.length - 1] as ToolCallback;
+  }
+
+  const surface = { surface: 'parse', scoped: false };
+
+  it('passes arguments and results through unchanged', async () => {
+    const { server, registrations } = fakeServer();
+    const handler = jest.fn().mockResolvedValue({ content: [] });
+
+    instrumentToolUsage(server as unknown as McpServer, surface).tool(
+      'parseFile',
+      'description',
+      {},
+      handler
+    );
+
+    const registration = registrations[0]!;
+    expect(registration.slice(0, 3)).toEqual(['parseFile', 'description', {}]);
+
+    const extra = { authInfo: AUTHENTICATED };
+    await expect(
+      registeredCallback(registration)({ fileId: 'file_1' }, extra)
+    ).resolves.toEqual({ content: [] });
+    expect(handler).toHaveBeenCalledWith({ fileId: 'file_1' }, extra);
+  });
+
+  it('rethrows so the SDK still reports the failure to the client', async () => {
+    const { server, registrations } = fakeServer();
+
+    instrumentToolUsage(server as unknown as McpServer, surface).tool(
+      'parseFile',
+      'description',
+      {},
+      jest.fn().mockRejectedValue(new Error('parse exploded'))
+    );
+
+    await expect(
+      registeredCallback(registrations[0]!)(
+        { fileId: 'file_1' },
+        { authInfo: AUTHENTICATED }
+      )
+    ).rejects.toThrow('parse exploded');
+  });
+
+  it('handles the schemaless callback shape, where extra is the only argument', async () => {
+    const { server, registrations } = fakeServer();
+    const handler = jest.fn().mockResolvedValue({ content: [] });
+
+    instrumentToolUsage(server as unknown as McpServer, surface).tool(
+      'noSchema',
+      handler
+    );
+
+    const extra = { authInfo: AUTHENTICATED };
+    await expect(registeredCallback(registrations[0]!)(extra)).resolves.toEqual(
+      { content: [] }
+    );
+    expect(handler).toHaveBeenCalledWith(extra);
+  });
+
+  it('leaves other server members reachable through the proxy', () => {
+    const { server } = fakeServer();
+    const instrumented = instrumentToolUsage(
+      server as unknown as McpServer,
+      surface
+    ) as unknown as { unrelated: () => string };
+
+    expect(instrumented.unrelated()).toBe('passed through');
+  });
+});

--- a/lib/business/client.ts
+++ b/lib/business/client.ts
@@ -1,0 +1,23 @@
+import LlamaCloud from '@llamaindex/llama-cloud';
+import { llamaCloudBaseUrl } from '../region';
+
+/**
+ * Identifies this server to the LlamaCloud API. The platform buckets
+ * `X-SDK-Name` against a closed allowlist and emits it as a metric label;
+ * anything outside that allowlist is recorded as `other`.
+ */
+export const SDK_NAME = 'llamacloud-mcp';
+
+export const SDK_NAME_HEADER = 'X-SDK-Name';
+
+/**
+ * Every LlamaCloud call goes through here so a new call site cannot forget the
+ * header — it is the only thing tying platform usage back to this server.
+ */
+export function llamaCloudClient(authToken: string): LlamaCloud {
+  return new LlamaCloud({
+    apiKey: authToken,
+    baseURL: llamaCloudBaseUrl(),
+    defaultHeaders: { [SDK_NAME_HEADER]: SDK_NAME },
+  });
+}

--- a/lib/business/liteparse.ts
+++ b/lib/business/liteparse.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { LiteParse as LiteParseType } from '@llamaindex/liteparse-wasm';
-import LlamaCloud from '@llamaindex/llama-cloud';
-import { llamaCloudBaseUrl } from '../region';
+import type LlamaCloud from '@llamaindex/llama-cloud';
+import { llamaCloudClient } from './client';
 
 // Lazy loader: initializes the wasm module once and caches the constructor.
 //
@@ -240,10 +240,7 @@ export async function isComplex({
   fileId: string;
   includeLayout?: boolean;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   const Liteparse = await getLiteParse();
   const lit = new Liteparse({
     ocrEnabled: false,
@@ -322,10 +319,7 @@ export async function litParse({
   markdown?: boolean;
   includeJson?: boolean;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   const Liteparse = await getLiteParse();
   const lit = new Liteparse({
     ocrEnabled: false,

--- a/lib/business/llamaparse.ts
+++ b/lib/business/llamaparse.ts
@@ -1,4 +1,3 @@
-import LlamaCloud from '@llamaindex/llama-cloud';
 import {
   CategoryType,
   ClassifyResult,
@@ -7,7 +6,7 @@ import {
   SplitResult,
 } from './types';
 import { RetrievalGrepResponse } from '@llamaindex/llama-cloud/resources/beta.js';
-import { llamaCloudBaseUrl } from '../region';
+import { llamaCloudClient } from './client';
 
 const MaximumWaitingTime: number = 1800 * 1000;
 const MaxDelay: number = 60;
@@ -31,10 +30,7 @@ export async function uploadFile({
   fileType?: string | undefined;
   projectId?: string | undefined;
 }): Promise<string> {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   let bytes;
   if (typeof fileData === 'string') {
     const binaryString = atob(fileData);
@@ -78,10 +74,7 @@ export async function parseFile({
   projectId?: string | undefined;
   pages?: number[] | undefined;
 }): Promise<ParsingResult> {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   const expand = [markdown ? 'markdown_full' : 'text_full'];
   const result = await client.parsing.parse({
     version: version ?? 'latest',
@@ -119,10 +112,7 @@ export async function classifyFile({
   projectId?: string | undefined;
   configurationId?: string | undefined;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
 
   if (!configurationId && !categories) {
     throw new Error(
@@ -195,10 +185,7 @@ export async function splitFile({
   projectId?: string | undefined;
   configurationId?: string | undefined;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
 
   if (!configurationId && !categories) {
     throw new Error(
@@ -253,10 +240,7 @@ export async function splitFile({
 }
 
 export async function getProjects(authToken: string): Promise<string[]> {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   const projects = await client.projects.list();
   const projectIds = projects.map((p) => p.id);
   return projectIds;
@@ -273,10 +257,7 @@ export async function generateExtractSchema({
   projectId?: string | undefined;
   generationPrompt: string;
 }): Promise<[string, string]> {
-  const client = new LlamaCloud({
-    apiKey: token,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(token);
   const configCreateReq = await client.extract.generateSchema({
     project_id: projectId,
     prompt: generationPrompt,
@@ -304,10 +285,7 @@ export async function extract({
   projectId?: string | undefined;
   configurationId: string;
 }) {
-  const client = new LlamaCloud({
-    apiKey: token,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(token);
   const response = await client.extract.run({
     file_input: fileId,
     configuration_id: configurationId,
@@ -343,10 +321,7 @@ export async function listIndexes({
   authToken: string;
   projectId?: string | null;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   let pageToken: string | undefined = undefined;
   const indexes: { name: string; indexId: string; description: string }[] = [];
   while (true) {
@@ -387,10 +362,7 @@ export async function searchFilesFromIndex({
   fileName?: string | null;
   fileNameContains?: string | null;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   let pageToken: string | undefined = undefined;
   const files: { name: string; fileId: string }[] = [];
   while (true) {
@@ -435,10 +407,7 @@ export async function readFileFromIndex({
   offset?: number | null;
   maxLength?: number | null;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   const response = await client.beta.retrieval.read({
     project_id: projectId,
     file_id: fileId,
@@ -466,10 +435,7 @@ export async function grepFileFromIndex({
   contextChars?: number | null;
   limit?: number | null;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   const grepMatches: RetrievalGrepResponse[] = [];
   let pageToken: string | undefined = undefined;
   while (true) {
@@ -510,10 +476,7 @@ export async function retrieveFromIndex({
   topK?: number | null;
   rerankTopN?: number | null;
 }) {
-  const client = new LlamaCloud({
-    apiKey: authToken,
-    baseURL: llamaCloudBaseUrl(),
-  });
+  const client = llamaCloudClient(authToken);
   const response = await client.beta.retrieval.retrieve({
     project_id: projectId,
     index_id: indexId,

--- a/lib/business/organization.ts
+++ b/lib/business/organization.ts
@@ -1,0 +1,121 @@
+import LlamaCloud from '@llamaindex/llama-cloud';
+import { llamaCloudClient } from './client';
+import { getLogger } from '../observability/logger';
+
+/**
+ * Resolve the LlamaCloud organization a caller's usage belongs to. Not the
+ * WorkOS `org_id` claim — a different id space, which would group to nothing.
+ */
+
+/** Bounds staleness after a genuine move; membership rarely changes. */
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+/** Best-effort, so a short budget: the client defaults suit awaited calls. */
+const LOOKUP_TIMEOUT_MS = 5_000;
+const LOOKUP_MAX_RETRIES = 0;
+
+/** The cache lives as long as a warm instance, so it needs a ceiling. */
+const MAX_CACHE_ENTRIES = 1000;
+
+type CacheEntry = {
+  organizationId: string | undefined;
+  expiresAt: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+function cacheKey(userId: string, projectId: string | undefined): string {
+  // A user can hold projects in more than one organization, so the project is
+  // part of the answer's identity.
+  return `${userId}\u0000${projectId ?? ''}`;
+}
+
+function readCache(key: string): CacheEntry | undefined {
+  const entry = cache.get(key);
+  if (!entry) {
+    return undefined;
+  }
+  if (entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return undefined;
+  }
+  // Re-insert to move the entry to the end, so eviction drops the least
+  // recently *used* key rather than the oldest write.
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry;
+}
+
+function writeCache(key: string, organizationId: string | undefined): void {
+  if (cache.size >= MAX_CACHE_ENTRIES && !cache.has(key)) {
+    // Map iterates in insertion order, and reads re-insert, so the first key
+    // is the least recently used.
+    const evicted = cache.keys().next();
+    if (!evicted.done) {
+      cache.delete(evicted.value);
+    }
+  }
+  cache.set(key, { organizationId, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/** Exposed for tests; a warm instance otherwise carries entries between them. */
+export function clearOrganizationCache(): void {
+  cache.clear();
+}
+
+const REQUEST_OPTIONS = {
+  timeout: LOOKUP_TIMEOUT_MS,
+  maxRetries: LOOKUP_MAX_RETRIES,
+};
+
+/**
+ * A named project is fetched directly; the listing is unpaginated, so a caller
+ * with enough projects could have theirs fall outside it. With none named, only
+ * the default will do — an arbitrary one would name the wrong organization,
+ * which is worse than recording nothing.
+ */
+async function fetchOrganizationId(
+  client: LlamaCloud,
+  projectId: string | undefined
+): Promise<string | undefined> {
+  if (projectId) {
+    const project = await client.projects.get(
+      projectId,
+      undefined,
+      REQUEST_OPTIONS
+    );
+    return project.organization_id;
+  }
+  const projects = await client.projects.list(undefined, REQUEST_OPTIONS);
+  return projects.find((project) => project.is_default)?.organization_id;
+}
+
+export async function resolveOrganizationId({
+  authToken,
+  userId,
+  projectId,
+}: {
+  authToken: string;
+  userId: string;
+  projectId?: string | undefined;
+}): Promise<string | undefined> {
+  const key = cacheKey(userId, projectId);
+  const cached = readCache(key);
+  if (cached) {
+    return cached.organizationId;
+  }
+
+  try {
+    const organizationId = await fetchOrganizationId(
+      llamaCloudClient(authToken),
+      projectId
+    );
+    writeCache(key, organizationId);
+    return organizationId;
+  } catch (error) {
+    // Not cached: a transient API failure should not blind attribution for the
+    // next ten minutes.
+    getLogger().warn(`Could not resolve the organization for usage: ${error}`);
+    return undefined;
+  }
+}

--- a/lib/mcp/handler.ts
+++ b/lib/mcp/handler.ts
@@ -9,6 +9,10 @@ import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
 import { getLogger } from '@/lib/observability/logger';
 import { extractRateLimitFromResponse } from '@/lib/auth/helpers';
 import { invalidTokenError } from '@/lib/auth/token-errors';
+import {
+  instrumentToolUsage,
+  surfaceFromBasePath,
+} from '@/lib/observability/usage';
 import type { McpServer } from '@/lib/mcp/tools/tools';
 
 const clientId = process.env.WORKOS_CLIENT_ID;
@@ -67,9 +71,14 @@ export function buildMcpRouteHandler(
   basePath: string,
   serverInfo?: McpServerInfo
 ) {
+  // Usage accounting is attached here rather than inside each `register`
+  // function, so a tool added later is covered without anyone remembering to
+  // opt it in.
+  const surface = surfaceFromBasePath(basePath);
+
   const handler = createMcpHandler(
     (server) => {
-      register(server);
+      register(instrumentToolUsage(server, surface));
     },
     { ...serverInfo },
     { basePath }

--- a/lib/observability/posthog.ts
+++ b/lib/observability/posthog.ts
@@ -1,0 +1,116 @@
+import { PostHog } from 'posthog-node';
+import { getLogger } from './logger';
+import { UNKNOWN, type ToolUsageEvent } from './usage-event';
+
+/**
+ * Product analytics for MCP tool calls. PostHog identifies people by the raw
+ * auth-provider UID — the same WorkOS user id resolved here — so MCP usage
+ * lands on the same person as that user's console and API activity, with no
+ * identity mapping.
+ */
+
+/** One event for every tool, with the tool as a property. */
+export const TOOL_CALL_EVENT = 'mcp.tool.call';
+
+/** Matches what the platform sets; org insights need both to agree. */
+const ORGANIZATION_GROUP = 'organization';
+
+/**
+ * Matches the platform's default. A deployment reporting elsewhere sets
+ * `POSTHOG_HOST`; the host is deployment configuration, not derived from
+ * `LLAMA_CLOUD_REGION`.
+ */
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+let cachedClient: PostHog | null | undefined;
+
+function resolveHost(): string {
+  return process.env.POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST;
+}
+
+/**
+ * Vercel builds a preview per branch, running the same code against the same
+ * key — without this, preview traffic looks like production.
+ */
+function environment(): string {
+  return process.env.VERCEL_ENV?.trim() || 'development';
+}
+
+/**
+ * Null when unconfigured. Absent key means off, not broken: local and
+ * self-hosted deployments have no project and must not fail or log per call.
+ */
+function getPostHogClient(): PostHog | null {
+  if (cachedClient !== undefined) {
+    return cachedClient;
+  }
+  const apiKey = process.env.POSTHOG_API_KEY?.trim();
+  if (!apiKey) {
+    cachedClient = null;
+    return cachedClient;
+  }
+  cachedClient = new PostHog(apiKey, {
+    host: resolveHost(),
+    // Everything goes out via `captureImmediate`, so the flush timer would
+    // only ever fire on an empty queue.
+    flushAt: 1,
+  });
+  return cachedClient;
+}
+
+/** Exposed for tests, which need a fresh client per environment permutation. */
+export function resetPostHogClient(): void {
+  cachedClient = undefined;
+}
+
+/** snake_case to match the platform's own events, so breakdowns behave alike. */
+function toProperties(
+  event: ToolUsageEvent
+): Record<string, string | number | boolean> {
+  const properties: Record<string, string | number | boolean> = {
+    tool: event.tool,
+    surface: event.surface,
+    scoped: event.scoped,
+    region: event.region,
+    user_id: event.userId,
+    project_id: event.projectId,
+    outcome: event.outcome,
+    duration_ms: event.durationMs,
+    environment: environment(),
+  };
+  if (event.organizationId !== UNKNOWN) {
+    properties.organization_id = event.organizationId;
+  }
+  return properties;
+}
+
+/**
+ * `captureImmediate`, not the batching `capture`: the function can freeze the
+ * moment it returns, and a queued event would be lost without erroring. An
+ * undercount is worse than a gap, because it still looks like real data.
+ */
+export async function captureToolUsage(event: ToolUsageEvent): Promise<void> {
+  const client = getPostHogClient();
+  if (!client) {
+    return;
+  }
+  if (event.userId === UNKNOWN) {
+    // No person to attribute; a placeholder id would merge every such caller
+    // into one shared profile.
+    return;
+  }
+
+  try {
+    await client.captureImmediate({
+      distinctId: event.userId,
+      event: TOOL_CALL_EVENT,
+      properties: toProperties(event),
+      groups:
+        event.organizationId === UNKNOWN
+          ? undefined
+          : { [ORGANIZATION_GROUP]: event.organizationId },
+    });
+  } catch (error) {
+    getLogger().warn(`Could not report usage to PostHog: ${error}`);
+  }
+}

--- a/lib/observability/usage-event.ts
+++ b/lib/observability/usage-event.ts
@@ -1,0 +1,41 @@
+/**
+ * Event shape, held apart from both its producer (`usage.ts`) and its PostHog
+ * sink, which would otherwise import each other in a cycle.
+ */
+
+/** Value recorded when a dimension cannot be resolved. */
+export const UNKNOWN = 'unknown';
+
+export type ToolOutcome =
+  | 'success'
+  | 'tool_error'
+  | 'rate_limited'
+  | 'unauthenticated'
+  | 'exception';
+
+/**
+ * `surface` is the base path's first segment — a literal in every route file,
+ * so the value set stays closed despite `/index/[indexId]` and
+ * `/classify/[configId]` carrying a caller-supplied segment. `scoped` records
+ * whether that segment was present.
+ */
+export type UsageSurface = {
+  surface: string;
+  scoped: boolean;
+};
+
+export type ToolUsageEvent = {
+  tool: string;
+  surface: string;
+  scoped: boolean;
+  region: string;
+  userId: string;
+  projectId: string;
+  /**
+   * LlamaCloud organization id, not the WorkOS `org_id` claim — separate id
+   * spaces, and the platform's analytics group on the former.
+   */
+  organizationId: string;
+  outcome: ToolOutcome;
+  durationMs: number;
+};

--- a/lib/observability/usage.ts
+++ b/lib/observability/usage.ts
@@ -1,0 +1,272 @@
+import { trace, type Span } from '@opentelemetry/api';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { McpServer } from '@/lib/mcp/tools/tools';
+import type { WorkOSAuthInfo } from '@/lib/auth/types';
+import { resolveOrganizationId } from '@/lib/business/organization';
+import { getRegion } from '@/lib/region';
+import { captureToolUsage } from './posthog';
+import { getLogger } from './logger';
+import {
+  UNKNOWN,
+  type ToolOutcome,
+  type ToolUsageEvent,
+  type UsageSurface,
+} from './usage-event';
+
+/**
+ * Per-tool-call usage accounting. Absent values are recorded as `unknown`
+ * rather than omitted, so a query never has to tell a missing field from an
+ * unresolvable one.
+ */
+
+const tracer = trace.getTracer('mcp-usage');
+
+// Re-exported so callers have one import; the definitions live apart to keep
+// this module and its PostHog sink out of an import cycle.
+export {
+  UNKNOWN,
+  type ToolOutcome,
+  type ToolUsageEvent,
+  type UsageSurface,
+} from './usage-event';
+
+/** Derive the closed-set surface label from a route's base path. */
+export function surfaceFromBasePath(basePath: string): UsageSurface {
+  const segments = basePath.split('/').filter(Boolean);
+  if (segments.length === 0) {
+    // The aggregate server at `/mcp`, which exposes every tool.
+    return { surface: 'full', scoped: false };
+  }
+  return { surface: segments[0]!, scoped: segments.length > 1 };
+}
+
+function workosAuth(
+  authInfo: AuthInfo | undefined
+): WorkOSAuthInfo | undefined {
+  if (!authInfo?.extra) {
+    return undefined;
+  }
+  const extra = authInfo.extra as WorkOSAuthInfo;
+  return extra.user ? extra : undefined;
+}
+
+/**
+ * Classify how the call ended. Rate limiting is separated from other tool
+ * errors because it is this server's own limiter turning users away, and it is
+ * read from the auth context rather than by matching on error text.
+ */
+export function classifyOutcome({
+  authInfo,
+  result,
+  threw,
+}: {
+  authInfo: AuthInfo | undefined;
+  result: unknown;
+  threw: boolean;
+}): ToolOutcome {
+  if (!workosAuth(authInfo)) {
+    return 'unauthenticated';
+  }
+  if (threw) {
+    return 'exception';
+  }
+  const isError =
+    typeof result === 'object' &&
+    result !== null &&
+    (result as { isError?: unknown }).isError === true;
+  if (!isError) {
+    return 'success';
+  }
+  return workosAuth(authInfo)?.rateLimit ? 'rate_limited' : 'tool_error';
+}
+
+function projectIdFromArgs(toolArgs: unknown): string {
+  if (typeof toolArgs !== 'object' || toolArgs === null) {
+    return UNKNOWN;
+  }
+  const projectId = (toolArgs as { projectId?: unknown }).projectId;
+  return typeof projectId === 'string' && projectId ? projectId : UNKNOWN;
+}
+
+function currentRegion(): string {
+  try {
+    return getRegion();
+  } catch {
+    // A bad region already fails the deployment at boot; it must not also take
+    // down the call reporting it.
+    return UNKNOWN;
+  }
+}
+
+export function buildToolUsageEvent({
+  tool,
+  surface,
+  authInfo,
+  toolArgs,
+  organizationId,
+  outcome,
+  durationMs,
+}: {
+  tool: string;
+  surface: UsageSurface;
+  authInfo: AuthInfo | undefined;
+  toolArgs: unknown;
+  organizationId: string | undefined;
+  outcome: ToolOutcome;
+  durationMs: number;
+}): ToolUsageEvent {
+  const user = workosAuth(authInfo)?.user;
+  return {
+    tool,
+    surface: surface.surface,
+    scoped: surface.scoped,
+    region: currentRegion(),
+    userId: user?.id ?? UNKNOWN,
+    projectId: projectIdFromArgs(toolArgs),
+    organizationId: organizationId ?? UNKNOWN,
+    outcome,
+    durationMs,
+  };
+}
+
+/**
+ * Publish to both sinks. The log line is the fallback for when the trace
+ * exporter is unconfigured or failing, which would otherwise take the numbers
+ * silently to zero.
+ */
+export function recordToolUsage(span: Span, event: ToolUsageEvent): void {
+  span.setAttribute('mcp.tool', event.tool);
+  span.setAttribute('mcp.surface', event.surface);
+  span.setAttribute('mcp.scoped', event.scoped);
+  span.setAttribute('mcp.region', event.region);
+  span.setAttribute('mcp.user_id', event.userId);
+  span.setAttribute('mcp.project_id', event.projectId);
+  span.setAttribute('mcp.organization_id', event.organizationId);
+  span.setAttribute('mcp.outcome', event.outcome);
+  span.setAttribute('mcp.duration_ms', event.durationMs);
+  getLogger().info('mcp.usage', event);
+}
+
+/** Skipped for unauthenticated calls: no token to look one up with. */
+async function organizationForUsage(
+  authInfo: AuthInfo | undefined,
+  toolArgs: unknown
+): Promise<string | undefined> {
+  const user = workosAuth(authInfo)?.user;
+  if (!user || !authInfo?.token) {
+    return undefined;
+  }
+  const projectId = projectIdFromArgs(toolArgs);
+  return resolveOrganizationId({
+    authToken: authInfo.token,
+    userId: user.id,
+    projectId: projectId === UNKNOWN ? undefined : projectId,
+  });
+}
+
+/**
+ * The SDK calls back as `(args, extra)` with an input schema and `(extra)`
+ * without, so `extra` is found from the end rather than by index.
+ */
+type ToolCallback = (...args: unknown[]) => unknown;
+
+function withUsageAccounting(
+  tool: string,
+  surface: UsageSurface,
+  callback: ToolCallback
+): ToolCallback {
+  return async (...callbackArgs: unknown[]) => {
+    const extra = callbackArgs[callbackArgs.length - 1] as
+      | { authInfo?: AuthInfo }
+      | undefined;
+    const toolArgs = callbackArgs.length > 1 ? callbackArgs[0] : undefined;
+    const authInfo = extra?.authInfo;
+
+    return tracer.startActiveSpan('mcp.tool_call', async (span) => {
+      const startedAt = Date.now();
+      // Started here rather than awaited in `finally`: an `await` there holds
+      // the tool's response until it settles, which would put a cache-miss
+      // lookup on the caller's critical path. It depends on nothing the tool
+      // produces, so it runs alongside instead. Rejections are absorbed now
+      // because nothing awaits it until the call is over.
+      const organizationId = organizationForUsage(authInfo, toolArgs).catch(
+        () => undefined
+      );
+      let result: unknown;
+      let threw = false;
+      try {
+        result = await callback(...callbackArgs);
+        return result;
+      } catch (error) {
+        threw = true;
+        // Rethrown unchanged: the SDK turns a throw into an `isError` result
+        // for the client, and swallowing it here would change what callers see.
+        throw error;
+      } finally {
+        const durationMs = Date.now() - startedAt;
+        try {
+          const event = buildToolUsageEvent({
+            tool,
+            surface,
+            authInfo,
+            toolArgs,
+            organizationId: await organizationId,
+            outcome: classifyOutcome({ authInfo, result, threw }),
+            durationMs,
+          });
+          recordToolUsage(span, event);
+          // Awaited, not deferred: the function can freeze the moment it
+          // returns, and an in-flight event would be lost without erroring.
+          await captureToolUsage(event);
+        } catch {
+          // Accounting is never worth failing a tool call over.
+        }
+        span.end();
+      }
+    });
+  };
+}
+
+/**
+ * Wrap a server so every tool registered on it is accounted for. Applied at the
+ * route seam rather than per tool, so the next tool added is covered too.
+ */
+export function instrumentToolUsage(
+  server: McpServer,
+  surface: UsageSurface
+): McpServer {
+  // `tool()` is overloaded, but the name is always first and the callback
+  // always last, so the wrapper ignores everything in between.
+  const registerTool = server.tool.bind(server) as (
+    ...args: unknown[]
+  ) => unknown;
+
+  const wrappedTool = (...registrationArgs: unknown[]) => {
+    const lastIndex = registrationArgs.length - 1;
+    const callback = registrationArgs[lastIndex];
+    if (typeof callback === 'function') {
+      const tool =
+        typeof registrationArgs[0] === 'string' ? registrationArgs[0] : UNKNOWN;
+      registrationArgs[lastIndex] = withUsageAccounting(
+        tool,
+        surface,
+        callback as ToolCallback
+      );
+    }
+    return registerTool(...registrationArgs);
+  };
+
+  return new Proxy(server, {
+    get(target, property) {
+      if (property === 'tool') {
+        return wrappedTool;
+      }
+      // Bound to the real server: SDK methods read private fields, which a
+      // proxy receiver would break.
+      const value = Reflect.get(target, property) as unknown;
+      return typeof value === 'function'
+        ? (value as (...args: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  }) as McpServer;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jose": "^6.0.11",
     "next": "15.3.8",
     "next-themes": "^0.4.6",
+    "posthog-node": "^5.48.0",
     "rate-limiter-flexible": "^11.0.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      posthog-node:
+        specifier: ^5.48.0
+        version: 5.48.0
       rate-limiter-flexible:
         specifier: ^11.0.0
         version: 11.0.0
@@ -732,6 +735,12 @@ packages:
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@posthog/core@1.46.8':
+    resolution: {integrity: sha512-WQTSwlFhsWk09xngTimHiTyhFU8QZHFZEGSm+6brY3acwYdvTLcTxpIhgl/qOCgn/XoqlCFTZqU1ldWLxNntfA==}
+
+  '@posthog/types@1.402.1':
+    resolution: {integrity: sha512-4PZ9wMYI8m8AqJuZ9YR1IAHGVtSnYbBVBgTevrKpzZbcSe/OUwhEV2Ks//rJh/L8eMTU8R5DrD4D/hlrOwaAiQ==}
 
   '@redis/bloom@1.2.0':
     resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
@@ -2852,6 +2861,15 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-node@5.48.0:
+    resolution: {integrity: sha512-YIH82XV24aa1nnVph1ndiW/vBN2QDIKlrHNEJcmAYutMGeoGC4WeEefg7O5aD3dDcO5dzociy8sVwXq4tNDYsQ==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4159,6 +4177,12 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@posthog/core@1.46.8':
+    dependencies:
+      '@posthog/types': 1.402.1
+
+  '@posthog/types@1.402.1': {}
 
   '@redis/bloom@1.2.0(@redis/client@1.6.1)':
     dependencies:
@@ -6679,6 +6703,10 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  posthog-node@5.48.0:
+    dependencies:
+      '@posthog/core': 1.46.8
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## What this fixes

Nothing recorded who used this server or how. Tool calls that reach LlamaCloud produce usage rows on the platform, but nothing on them says they came from here — they look like the user's own SDK traffic. `parseWithLiteParse` and `estimateFileComplexity` run the WASM parser in-process and never reach the platform, so they left no record anywhere. And none of it sat alongside the rest of the product analytics, so "who adopts MCP and which tools do they use" could not be asked against the same people as everything else.

## What changed

**Per-call accounting.** Each tool call emits one `mcp.tool.call` event to PostHog, plus an `mcp.tool_call` span and an `mcp.usage` log line — the fallback for when the trace exporter is failing, the case where the numbers would otherwise silently go to zero. Dimensions: tool, surface, scoped, region, user id, project, organization, outcome, duration. Absent values are recorded as `unknown`, so a query never has to tell a missing field from an unresolvable one.

**Why PostHog.** It identifies people by the raw auth-provider UID, which is the WorkOS user id this server already resolves, so MCP usage lands on the same person as that user's console sessions and API calls with no identity mapping to build or keep correct. One event with the tool as a property, so a tool added later shows up in existing breakdowns on its own.

**Organization attribution.** Events carry the LlamaCloud `organization` group. Every tool already takes a `projectId`, and a project fetched by id carries its organization, so the common path is one targeted request. The lookup starts alongside the tool rather than after it, is bounded at 5s with no retries, and its cache evicts least-recently-used — so a cache miss never lands on the caller's critical path and an unreachable API costs attribution rather than the call.

**Identifying header.** All 15 LlamaCloud client constructions go through one factory that sets `X-SDK-Name: llamacloud-mcp`.

## Decisions worth reviewing

- **Not the WorkOS `org_id` claim.** Tempting, since the verified token is already in hand — but WorkOS organizations and LlamaCloud organizations are separate id spaces, and PostHog groups key on the latter. Grouping on the claim would quietly create a second set of organization groups that join to nothing, which is precisely the org-level insight this is meant to feed.
- **No arbitrary organization when no project is named.** Only the caller's default project will do. Picking any other would attribute the usage to whichever organization came back first — silently wrong, which is worse than the `unknown` that missing attribution records.
- **Not the project listing.** It is unpaginated — the SDK exposes no page size or token — so a caller with enough projects could have theirs fall outside it.
- **No email domain.** An earlier revision derived one for account-level attribution. `main` has since reduced `User` to `{ id }` and dropped the WorkOS profile fetch, on the grounds that `sub` already is the user id and the round-trip bought a field no tool read. Re-adding that fetch to label analytics would reinstate exactly the cost that was removed, on every call. The user id still carries the join; organization is the account-level axis.
- **Immediate, awaited delivery.** Not batched, and not deferred to a post-response hook. The function can freeze the moment it returns and a queued event would be dropped without erroring; an undercount that still looks like real data is worse than a missing metric.
- **Surface label is the first path segment.** `/index/[indexId]` and `/classify/[configId]` carry caller-controlled ids; the full base path would be unbounded.
- **Attached at the route seam, not per tool.** `buildMcpRouteHandler` wraps the server before `register` sees it, so all 15 tools are covered and a tool added later cannot miss it.
- **Never fails a call.** Throws rethrown unchanged, record failures swallowed, unauthenticated calls dropped rather than merged under a placeholder distinct_id, reporting off entirely when no key is set.
- **Counts calls, not pages.** LiteParse only returns per-page detail when a caller asks for it, so a page count would be missing for most calls.

## Configuration

`POSTHOG_API_KEY` enables reporting; unset disables it — so merging this alone changes nothing until the key is set on the deployment. `POSTHOG_HOST` optionally overrides the default (`https://us.i.posthog.com`, matching the platform).

Use the same PostHog project the console and API report to. A different project would render a dashboard whose organization groups match nothing, which looks like it worked.

## Companion change

run-llama/platform#23592 adds `llamacloud-mcp` to the `X-SDK-Name` allowlist — without it the header buckets to `other` — and adds the PostHog dashboard and liveness alert that read these events.

## Testing

CI green. 211 tests across 11 suites, plus `pnpm lint`, `pnpm prettier`, `tsc --noEmit` and `pnpm build`.

Tests cover surface derivation, all five outcome classifications, event construction, wrapper pass-through / rethrow / schemaless-callback behavior, organization resolution (that a named project never touches the listing, that no default yields nothing rather than a guess, and that a transient API failure is not cached), and the full PostHog payload — distinct_id, group tagging, snake_case properties, host resolution, and the drop/disable paths.