### PR TITLE
docs: cover the EU deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,14 @@ MCP Client (Claude, Cursor, etc.)
 
 ## Using the hosted version
 
-A production instance is already running at **`https://mcp.llamaindex.ai/mcp`**. You can connect any MCP-compatible client directly — no server setup required.
+Production instances are already running in two regions. Pick the one that matches your LlamaCloud account — no server setup required either way.
+
+| LlamaCloud account | MCP endpoint |
+|------|-------------|
+| `cloud.llamaindex.ai` (NA) | **`https://mcp.llamaindex.ai/mcp`** |
+| `cloud.eu.llamaindex.ai` (EU) | **`https://mcp.eu.llamaindex.ai/mcp`** |
+
+Region is a property of your account, not a per-session choice: a token issued in one region is rejected by the other with a `401` naming the correct endpoint. The client configurations below use the NA URL — substitute the EU URL if your account lives in the EU.
 
 ### Claude Desktop
 

--- a/skills/llamaparse-mcp/SKILL.md
+++ b/skills/llamaparse-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: llamaparse-mcp
 description: Skill on how to use the LlamaParse MCP tools
-compatibility: Needs authenticated access to https://mcp.llamaindex.ai/mcp
+compatibility: Needs authenticated access to a regional endpoint — https://mcp.llamaindex.ai/mcp (NA) or https://mcp.eu.llamaindex.ai/mcp (EU)
 license: MIT
 metadata:
   author: LlamaIndex
@@ -13,6 +13,8 @@ metadata:
 ## Authentication
 
 All tools require a valid session. If a tool call returns an authentication error, ask the user to re-authenticate before retrying. Do not retry automatically without prompting the user.
+
+The server runs as two regional deployments — `https://mcp.llamaindex.ai/mcp` for accounts on `cloud.llamaindex.ai`, and `https://mcp.eu.llamaindex.ai/mcp` for accounts on `cloud.eu.llamaindex.ai`. Region follows the user's LlamaCloud account, so it is not something to switch mid-session. A token issued for one region is rejected by the other with a `401` that names the correct endpoint; when that happens, tell the user to point their client at the endpoint named in the error rather than retrying.
 
 ## Uploading a File
 


### PR DESCRIPTION
`mcp.eu.llamaindex.ai` is live and serving from `fra1`, so the repo's own docs should describe both regions.

- **`README.md`** — the hosted-version section becomes a two-row table (NA / EU) with a note that region is a property of the LlamaCloud account rather than a per-session choice. Client configs below it keep the NA URL with an instruction to substitute.
- **`skills/llamaparse-mcp/SKILL.md`** — the `compatibility:` line names both endpoints, and a new paragraph tells the agent what to do on a cross-region 401: surface the endpoint named in the error rather than retrying.

The 401-names-the-correct-endpoint behaviour was verified live in both directions before writing this.

Companion docs PR on the platform side: run-llama/platform#23700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kf3KMnh4BEJQTVFpVHwuoz