### PR TITLE
LI-8664: record a page count, not stringified functions

### DIFF
--- a/lib/mcp/tools/tools.ts
+++ b/lib/mcp/tools/tools.ts
@@ -399,11 +399,7 @@ export function registerLitParseTool(server: McpServer) {
           span.setAttribute('tool.markdown', args.markdown);
         if (typeof args.includeJson !== 'undefined')
           span.setAttribute('tool.include_json', args.includeJson);
-        if (args.pages)
-          span.setAttribute(
-            'tool.version',
-            args.pages.map((p) => p.toString).join(', ')
-          );
+        if (args.pages) span.setAttribute('tool.page_count', args.pages.length);
         const { authInfo } = extra;
         ensureUserAuthenticated(authInfo);
         const logger = getLogger();


### PR DESCRIPTION
Found while reviewing #26, left out of it to keep that diff focused.

`parseWithLiteParse` recorded its page selection as:

```ts
args.pages.map((p) => p.toString).join(', ')
```

The call parens are missing. `p.toString` is the function object, and `join` stringifies it, so the attribute holds function source rather than page numbers:

```
"function toString() { [native code] }, function toString() { [native code] }, ..."
```

Three pages produce 115 characters of that. A 500-page selection would put roughly **19KB** into a single span attribute.

It was also written to `tool.version`, which `parseFile` uses for a genuine version value — so two unrelated things shared one attribute name in the same dataset.

Replaced with `tool.page_count`, which is the signal that was actually wanted. Nothing can be depending on the old value, since it never contained page numbers.

Gates: 182 tests across 8 suites, `eslint`, `prettier --check`, `tsc --noEmit` — all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kf3KMnh4BEJQTVFpVHwuoz


Closes LI-8664
